### PR TITLE
feat: add email field 'use as reply to' option

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/Edit
+ #: components/Edit
 msgid "Add field"
 msgstr "Add field"
 
@@ -167,3 +167,11 @@ msgstr "Sent!"
 #: components/Sidebar
 msgid "form_to"
 msgstr "Recipients"
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr "Use as 'reply to'"
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr "If selected, this will be the address the receiver can use to reply."

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr "Expédié!"
 #: components/Sidebar
 msgid "form_to"
 msgstr "Bénéficiaires"
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/Edit
+ #: components/Edit
 msgid "Add field"
 msgstr "Aggiungi campo"
 
@@ -167,3 +167,11 @@ msgstr "Inviato!"
 #: components/Sidebar
 msgid "form_to"
 msgstr "Destinatari"
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr "Usa come 'reply to'"
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr "Se selezionato, questo sarà l'indirizzo a cui il destinatario potrà rispondere."

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -167,3 +167,11 @@ msgstr ""
 #: components/Sidebar
 msgid "form_to"
 msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_useAsReplyTo_description"
+msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
  msgstr ""
  "Project-Id-Version: Plone\n"
- "POT-Creation-Date: 2021-03-24T18:15:47.623Z\n"
+ "POT-Creation-Date: 2021-04-07T13:07:21.178Z\n"
  "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "MIME-Version: 1.0\n"
@@ -207,4 +207,14 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Recipients
 msgid "form_to"
+msgstr ""
+
+#: components/Sidebar
+# defaultMessage: undefined
+msgid "form_useAsReplyTo"
+msgstr ""
+
+#: components/Sidebar
+# defaultMessage: undefined
+msgid "form_useAsReplyTo_description"
 msgstr ""

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -144,6 +144,15 @@ const messages = defineMessages({
     id: 'form_attachment_info_text',
     defaultMessage: 'Attached file will be sent via email, but not stored',
   },
+  useAsReplyTo: {
+    id: 'form_useAsReplyTo',
+    defineMessages: "Use as 'reply to'",
+  },
+  useAsReplyTo_description: {
+    id: 'form_useAsReplyTo_description',
+    defineMessages:
+      'If selected, this will be the address the receiver can use to reply.',
+  },
 });
 
 const Sidebar = ({
@@ -451,6 +460,25 @@ const Sidebar = ({
                         }}
                         required={true}
                         value={subblock.input_values}
+                      />
+                    )}
+
+                    {subblock.field_type === 'from' && (
+                      <CheckboxWidget
+                        id="useAsReplyTo"
+                        title={intl.formatMessage(messages.useAsReplyTo)}
+                        description={intl.formatMessage(
+                          messages.useAsReplyTo_description,
+                        )}
+                        value={
+                          subblock.useAsReplyTo ? subblock.useAsReplyTo : false
+                        }
+                        onChange={(name, value) => {
+                          onChangeSubBlock(index, {
+                            ...subblock,
+                            [name]: value,
+                          });
+                        }}
                       />
                     )}
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -465,13 +465,15 @@ const Sidebar = ({
 
                     {subblock.field_type === 'from' && (
                       <CheckboxWidget
-                        id="useAsReplyTo"
+                        id="use_as_reply_to"
                         title={intl.formatMessage(messages.useAsReplyTo)}
                         description={intl.formatMessage(
                           messages.useAsReplyTo_description,
                         )}
                         value={
-                          subblock.useAsReplyTo ? subblock.useAsReplyTo : false
+                          subblock.use_as_reply_to
+                            ? subblock.use_as_reply_to
+                            : false
                         }
                         onChange={(name, value) => {
                           onChangeSubBlock(index, {


### PR DESCRIPTION
Add a checkbox for the "email" field, so the address will be used as "reply to" within the submission.