### PR TITLE
feat: additionalFields from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ In Edit, you can export and clear stored data from the sidebar.
 
 <img alt="Form export" src="./docs/store-export-data.png" width="400" />
 
+## Additional fields
+
+In addition to the fields described above, you can add any field you want.
+If you need a field that is not supported, PRs are always welcome, but if you have to use a custom field tailored on your project needs, then you can add additional custom fields.
+
+```jsx
+config.blocks.blocksConfig.form.additionalFields.push({
+  id: 'field type id',
+  label:
+    intl.formatMessage(messages.customFieldLabel) ||
+    'Label for field type select, translation obj or string',
+  component: MyCustomWidget,
+});
+```
+
 ## Static fields
 
 In backend integration, you can add in block data an object called `static_fields` and the form block will show those in form view as readonly and will aggregate those with user compiled data.

--- a/README.md
+++ b/README.md
@@ -59,17 +59,7 @@ config.blocks.blocksConfig.form.additionalFields.push({
 The widget component should have the following firm:
 
 ```js
-({
-  id,
-  name,
-  title,
-  description,
-  required,
-  onChange,
-  value,
-  isDisabled,
-  invalid,
-}) => ReactElement;
+({ id, name, title, description, required, onChange, value, isDisabled, invalid }) => ReactElement;
 ```
 
 ## Static fields

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ config.blocks.blocksConfig.form.additionalFields.push({
 });
 ```
 
+The widget should have the following firm:
+
+```js
+({ id, name, title, description, required, onChange, value, isDisabled, invalid }) => ReactElement;
+```
+
 ## Static fields
 
 In backend integration, you can add in block data an object called `static_fields` and the form block will show those in form view as readonly and will aggregate those with user compiled data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # volto-block-form
 
-Volto addon which adds a customizable form using a block.  
+Volto addon which adds a customizable form using a block.
 Intended to be used with [collective.volto.formsupport](https://github.com/collective/collective.volto.formsupport).
 
 Install with mrs-developer (see [Volto docs](https://docs.voltocms.com/customizing/add-ons/)) or with:
@@ -52,13 +52,24 @@ config.blocks.blocksConfig.form.additionalFields.push({
     intl.formatMessage(messages.customFieldLabel) ||
     'Label for field type select, translation obj or string',
   component: MyCustomWidget,
+  isValid: (formData) => true,
 });
 ```
 
-The widget should have the following firm:
+The widget component should have the following firm:
 
 ```js
-({ id, name, title, description, required, onChange, value, isDisabled, invalid }) => ReactElement;
+({
+  id,
+  name,
+  title,
+  description,
+  required,
+  onChange,
+  value,
+  isDisabled,
+  invalid,
+}) => ReactElement;
 ```
 
 ## Static fields

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ config.blocks.blocksConfig.form.additionalFields.push({
     intl.formatMessage(messages.customFieldLabel) ||
     'Label for field type select, translation obj or string',
   component: MyCustomWidget,
-  isValid: (formData) => true,
+  isValid: (formData, name) => true,
 });
 ```
 
@@ -60,6 +60,15 @@ The widget component should have the following firm:
 
 ```js
 ({ id, name, title, description, required, onChange, value, isDisabled, invalid }) => ReactElement;
+```
+
+You should also pass a function to validate your field's data.
+The `isValid` function accepts `formData` (the whole form data) and the name of the field, thus you can access to your fields' data as `formData[name]` but you also have access to other fields.
+
+`isValid` has the firm:
+
+```js
+(formData, name) => boolean;
 ```
 
 ## Static fields

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr "Errore"
 msgid "Form"
 msgstr "Form"
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr "Form successfully submitted"
@@ -175,3 +179,7 @@ msgstr "Use as 'reply to'"
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
 msgstr "If selected, this will be the address the receiver can use to reply."
+
+#: components/Sidebar
+msgid "title"
+msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -29,7 +29,7 @@ msgstr "Form"
 
 #: components/Sidebar
 msgid "description"
-msgstr ""
+msgstr "Description"
 
 #: components/Form
 msgid "formSubmitted"
@@ -182,4 +182,4 @@ msgstr "If selected, this will be the address the receiver can use to reply."
 
 #: components/Sidebar
 msgid "title"
-msgstr ""
+msgstr "Title"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr "Erreur"
 msgid "Form"
 msgstr "Formulaire"
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr "Formulaire soumis avec succès"
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr "Errore"
 msgid "Form"
 msgstr "Form"
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr "Form invato correttamente"
@@ -175,3 +179,7 @@ msgstr "Usa come 'reply to'"
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
 msgstr "Se selezionato, questo sarà l'indirizzo a cui il destinatario potrà rispondere."
+
+#: components/Sidebar
+msgid "title"
+msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -29,7 +29,7 @@ msgstr "Form"
 
 #: components/Sidebar
 msgid "description"
-msgstr ""
+msgstr "Descrizione"
 
 #: components/Form
 msgid "formSubmitted"
@@ -182,4 +182,4 @@ msgstr "Se selezionato, questo sarà l'indirizzo a cui il destinatario potrà ri
 
 #: components/Sidebar
 msgid "title"
-msgstr ""
+msgstr "Titolo"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -17,207 +17,175 @@ msgstr ""
 "Domain: volto\n"
 "X-Generator: Poedit 2.4.3\n"
 
-# defaultMessage: Aggiungi un campo
-#: components/Edit
+ #: components/Edit
 msgid "Add field"
 msgstr "Adicionar campo"
 
-# defaultMessage: Cancel
 #: components/Sidebar
 msgid "Cancel"
 msgstr "Cancelar"
 
-# defaultMessage: Error
 #: components/FormView
 msgid "Error"
 msgstr "Erro"
 
-# defaultMessage: Form
 #: components/Sidebar
 msgid "Form"
 msgstr "Formulário"
 
-# defaultMessage: Form successfully submitted
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr " Formulário enviado com sucesso"
 
-# defaultMessage: Attached file will be sent via email, but not stored
 #: components/Sidebar
 msgid "form_attachment_info_text"
 msgstr "O arquivo anexado será enviado por e-mail, mas não armazenado"
 
-# defaultMessage: Clear data
 #: components/Sidebar
 msgid "form_clear_data"
 msgstr "Limpar dados"
 
-# defaultMessage: Are you sure you want to delete all saved items?
 #: components/Sidebar
 msgid "form_confirmClearData"
 msgstr "Você tem certeza que deseja apagar todos as respostas salvas?"
 
-# defaultMessage: Default sender
 #: components/Sidebar
 msgid "form_default_from"
 msgstr "Remetente padrão"
 
-# defaultMessage: This address will be used as the sender of the email with the form data
 #: components/Sidebar
 msgid "form_default_from_description"
 msgstr "Este endereço será utilizado como o remetente do e-mail com os dados do formulário"
 
-# defaultMessage: Mail subject
 #: components/Sidebar
 msgid "form_default_subject"
 msgstr "Assunto do e-mail"
 
-# defaultMessage: Invia
-#: components/Edit components/FormView
+#: components/Edit
+#: components/FormView
 msgid "form_default_submit_label"
 msgstr "Enviar"
 
-# defaultMessage: Export data
 #: components/Sidebar
 msgid "form_edit_exportCsv"
 msgstr "Exportar dados"
 
-# defaultMessage: Attenzione!
 #: components/Edit
 msgid "form_edit_warning"
 msgstr "Atenção"
 
-# defaultMessage: Enter a field of type 'Sender E-mail'. If it is not present, or it is present but not filled in by the user, the sender address of the e-mail will be the one configured in the right sidebar.
 #: components/Edit
 msgid "form_edit_warning_from"
 msgstr "Digite um campo do tipo 'E-mail do remetente'. Se não estiver presente, ou estiver presente mas não for preenchido pelo usuário, o endereço do remetente do e-mail será o configurado na barra lateral direita."
 
-# defaultMessage: Fill in the required fields
 #: components/FormView
 msgid "form_empty_values_validation"
 msgstr "Por favor preencha os campos obrigatórios"
 
-# defaultMessage: Description
 #: components/Sidebar
 msgid "form_field_description"
 msgstr "Descrição"
 
-# defaultMessage: Possible values
 #: components/Sidebar
 msgid "form_field_input_values"
 msgstr "Valores possíveis"
 
-# defaultMessage: Label
 #: components/Sidebar
 msgid "form_field_label"
 msgstr "Etiqueta"
 
-# defaultMessage: Name
 #: components/Sidebar
 msgid "form_field_name"
 msgstr "Nome"
 
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
 #: components/Sidebar
 msgid "form_field_name_description"
-msgstr "O nome deve conter espaços e só pode conter caracteres alfanuméricos além dos caracteres \"-\" e \"_\". O nome é igual ao nome do parâmetro."
+msgstr "O nome deve conter espaços e só pode conter caracteres alfanuméricos além dos caracteres "-" e "_". O nome é igual ao nome do parâmetro."
 
-# defaultMessage: Required
 #: components/Sidebar
 msgid "form_field_required"
 msgstr "Obrigatório"
 
-# defaultMessage: Field type
 #: components/Sidebar
 msgid "form_field_type"
 msgstr "Tipo de campo"
 
-# defaultMessage: Attachment
 #: components/Sidebar
 msgid "form_field_type_attachment"
 msgstr "Anexo"
 
-# defaultMessage: Multiple choice
 #: components/Sidebar
 msgid "form_field_type_checkbox"
 msgstr "Múltipla escolha"
 
-# defaultMessage: Date
 #: components/Sidebar
 msgid "form_field_type_date"
 msgstr "Data"
 
-# defaultMessage: E-mail
 #: components/Sidebar
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-# defaultMessage: Single choice
 #: components/Sidebar
 msgid "form_field_type_radio"
 msgstr "Escolha única"
 
-# defaultMessage: List
 #: components/Sidebar
 msgid "form_field_type_select"
 msgstr "Opções"
 
-# defaultMessage: Text
 #: components/Sidebar
 msgid "form_field_type_text"
 msgstr "Texto"
 
-# defaultMessage: Textarea
 #: components/Sidebar
 msgid "form_field_type_textarea"
 msgstr "Área de texto"
 
-# defaultMessage: {formDataCount} item(s) stored
 #: components/Sidebar
 msgid "form_formDataCount"
 msgstr "{formDataCount} item(ns) armazenados"
 
-# defaultMessage: Clear
 #: components/FormView
 msgid "form_reset"
 msgstr "Limpar"
 
-# defaultMessage: Store compiled data
 #: components/Sidebar
 msgid "form_save_persistent_data"
 msgstr "Armazenar dados"
 
-# defaultMessage: Seleziona un valore
 #: components/Field
 msgid "form_select_a_value"
 msgstr "Selecione um valor"
 
-# defaultMessage: Send email to recipient
 #: components/Sidebar
 msgid "form_send_email"
 msgstr "Enviar e-mail para o destinatário"
 
-# defaultMessage: Submit button label
 #: components/Sidebar
 msgid "form_submit_label"
 msgstr "Texto do botão de enviar"
 
-# defaultMessage: Sent!
 #: components/FormView
 msgid "form_submit_success"
 msgstr "Enviado!"
 
-# defaultMessage: Recipients
 #: components/Sidebar
 msgid "form_to"
 msgstr "Destinatários"
 
-# defaultMessage: undefined
 #: components/Sidebar
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'responder para'"
 
-# defaultMessage: undefined
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
-msgstr "Usar este campo como valor do cabeçalho de \"responder para\""
+msgstr "Usar este campo como valor do cabeçalho de "responder para""
+
+#: components/Sidebar
+msgid "title"
+msgstr ""

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -27,6 +27,10 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
+#: components/Sidebar
+msgid "description"
+msgstr ""
+
 #: components/Form
 msgid "formSubmitted"
 msgstr ""
@@ -174,4 +178,8 @@ msgstr ""
 
 #: components/Sidebar
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+msgid "title"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
  msgstr ""
  "Project-Id-Version: Plone\n"
- "POT-Creation-Date: 2021-04-07T13:07:21.178Z\n"
+ "POT-Creation-Date: 2021-08-03T07:34:46.833Z\n"
  "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "MIME-Version: 1.0\n"
@@ -31,6 +31,11 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"
+msgstr ""
+
+#: components/Sidebar
+# defaultMessage: Description
+msgid "description"
 msgstr ""
 
 #: components/Form
@@ -217,4 +222,9 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
+msgstr ""
+
+#: components/Sidebar
+# defaultMessage: Title
+msgid "title"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/collective/volto-form-block",
   "bugs": "https://github.com/collective/volto-form-block/issues",
   "author": "Nicola Zambello",
-  "homepage": "https://github.com/collective/volto-rss-block#readme",
+  "homepage": "https://github.com/collective/volto-form-block#readme",
   "license": "MIT",
   "keywords": [
     "volto-addon",

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -13,6 +13,8 @@ import RadioWidget from './Widget/RadioWidget';
 
 import './Field.css';
 
+import config from '@plone/volto/registry';
+
 const messages = defineMessages({
   select_a_value: {
     id: 'form_select_a_value',
@@ -172,6 +174,26 @@ const Field = ({
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
         />
       )}
+      {config.blocks.blocksConfig.form.additionalFields?.reduce((acc, val) => {
+        if (val.id === field_type)
+          return [
+            ...acc,
+            <val.component
+              id={name}
+              name={name}
+              title={label}
+              description={description}
+              required={required}
+              onChange={onChange}
+              value={value}
+              isDisabled={disabled}
+              invalid={isInvalid().toString()}
+              {...(isInvalid() ? { className: 'is-invalid' } : {})}
+            />,
+          ];
+
+        return acc;
+      }, []) ?? []}
     </div>
   );
 };

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -39,6 +39,7 @@ const Field = ({
   isOnEdit,
   valid,
   disabled = false,
+  formHasErrors = false,
 }) => {
   const intl = useIntl();
 
@@ -187,6 +188,7 @@ const Field = ({
               onChange={onChange}
               value={value}
               isDisabled={disabled}
+              formHasErrors={formHasErrors}
               invalid={isInvalid().toString()}
               {...(isInvalid() ? { className: 'is-invalid' } : {})}
             />,
@@ -211,6 +213,7 @@ Field.propTypes = {
   field_type: PropTypes.string,
   input_values: PropTypes.any,
   value: PropTypes.any,
+  formHasErrors: PropTypes.bool,
   onChange: PropTypes.func,
 };
 

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -6,6 +6,8 @@ import { submitForm } from '../actions';
 import { getFieldName } from './utils';
 import FormView from 'volto-form-block/components/FormView';
 
+import config from '@plone/volto/registry';
+
 const messages = defineMessages({
   formSubmitted: {
     id: 'formSubmitted',
@@ -92,9 +94,21 @@ const Form = ({ data, id, path }) => {
     let v = [];
     data.subblocks.forEach((subblock, index) => {
       let name = getFieldName(subblock.label);
+      let additionalField =
+        config.blocks.blocksConfig.form.additionalFields?.filter(
+          (f) => f.id === name && f.isValid !== undefined,
+        )?.[0] ?? null;
       if (
         subblock.required &&
-        (!formData[name] || formData[name]?.length === 0)
+        additionalField &&
+        !additionalField.isValid(formData, name)
+      )
+        v.push(name);
+      else if (
+        subblock.required &&
+        (!formData[name] ||
+          formData[name]?.value?.length === 0 ||
+          JSON.stringify(formData[name]?.value ?? {}) === '{}')
       ) {
         v.push(name);
       }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -94,14 +94,15 @@ const Form = ({ data, id, path }) => {
     let v = [];
     data.subblocks.forEach((subblock, index) => {
       let name = getFieldName(subblock.label);
+      let fieldType = subblock.field_type;
       let additionalField =
         config.blocks.blocksConfig.form.additionalFields?.filter(
-          (f) => f.id === name && f.isValid !== undefined,
+          (f) => f.id === fieldType && f.isValid !== undefined,
         )?.[0] ?? null;
       if (
         subblock.required &&
         additionalField &&
-        !additionalField.isValid(formData, name)
+        !additionalField?.isValid(formData, name)
       )
         v.push(name);
       else if (

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -111,6 +111,7 @@ const FormView = ({
                         onChange={() => {}}
                         disabled
                         valid
+                        formHasErrors={formErrors.length > 0}
                       />
                     </Grid.Column>
                   </Grid.Row>

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -101,7 +101,7 @@ const FormView = ({
             >
               <Grid columns={1} padded="vertically">
                 {data.static_fields?.map((field) => (
-                  <Grid.Row key={field.field_id}>
+                  <Grid.Row key={field.field_id} className="static-field">
                     <Grid.Column>
                       <Field
                         {...field}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -30,6 +30,8 @@ import deleteSVG from '@plone/volto/icons/delete.svg';
 
 import { getFormData, exportCsvFormData, clearFormData } from '../actions';
 
+import config from '@plone/volto/registry';
+
 const messages = defineMessages({
   title: {
     id: 'title',
@@ -466,6 +468,9 @@ const Sidebar = ({
                           intl.formatMessage(messages.field_type_attachment),
                         ],
                         ['from', intl.formatMessage(messages.field_type_from)],
+                        ...(config.blocks.blocksConfig.form.additionalFields?.map(
+                          (fieldType) => [fieldType.id, fieldType.label],
+                        ) ?? []),
                       ]}
                     />
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const applyConfig = (config) => {
       group: 'text',
       view: View,
       edit: Edit,
+      additionalFields: [],
       restricted: false,
       mostUsed: true,
       security: {


### PR DESCRIPTION
In addition to the existing fields, now you can add any field you want.
If you need a field that is not supported, PRs are always welcome, but if you have to use a custom field tailored on your project needs, then you can add additional custom fields.

```jsx
config.blocks.blocksConfig.form.additionalFields.push({
  id: 'field type id',
  label:
    intl.formatMessage(messages.customFieldLabel) ||
    'Label for field type select, translation obj or string',
  component: MyCustomWidget,
});
```