### PR TITLE
[BREAKING] add checkbox field, rename old checkbox and radio

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ For each field, you can select the field type from:
 - Text
 - Textarea
 - Select
-- Radio buttons
-- Checkbox buttons
+- Single choice (radio buttons)
+- Multiple choice (checkbox buttons)
+- Checkbox
 - Date picker
 - File upload with DnD
 - E-mail

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -114,7 +114,7 @@ msgstr "Attachment"
 
 #: components/Sidebar
 msgid "form_field_type_checkbox"
-msgstr "Multiple choice"
+msgstr "Checkbox"
 
 #: components/Sidebar
 msgid "form_field_type_date"
@@ -125,12 +125,16 @@ msgid "form_field_type_from"
 msgstr "E-mail"
 
 #: components/Sidebar
-msgid "form_field_type_radio"
-msgstr "Single choice"
+msgid "form_field_type_multiple_choice"
+msgstr "Multiple choice"
 
 #: components/Sidebar
 msgid "form_field_type_select"
 msgstr "List"
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
+msgstr "Single choice"
 
 #: components/Sidebar
 msgid "form_field_type_text"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -125,12 +125,16 @@ msgid "form_field_type_from"
 msgstr "E-mail"
 
 #: components/Sidebar
-msgid "form_field_type_radio"
-msgstr "Choix unique"
+msgid "form_field_type_multiple_choice"
+msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
 msgstr "Lister"
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
+msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_text"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -114,7 +114,7 @@ msgstr "Allegato"
 
 #: components/Sidebar
 msgid "form_field_type_checkbox"
-msgstr "Scelta multpla"
+msgstr "Checkbox"
 
 #: components/Sidebar
 msgid "form_field_type_date"
@@ -125,12 +125,16 @@ msgid "form_field_type_from"
 msgstr "E-mail"
 
 #: components/Sidebar
-msgid "form_field_type_radio"
-msgstr "Scelta singola"
+msgid "form_field_type_multiple_choice"
+msgstr "Scelta multipla"
 
 #: components/Sidebar
 msgid "form_field_type_select"
 msgstr "Lista"
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
+msgstr "Scelta singola"
 
 #: components/Sidebar
 msgid "form_field_type_text"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -131,12 +131,16 @@ msgid "form_field_type_from"
 msgstr "E-mail"
 
 #: components/Sidebar
-msgid "form_field_type_radio"
-msgstr "Escolha única"
+msgid "form_field_type_multiple_choice"
+msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
 msgstr "Opções"
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
+msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_text"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -125,11 +125,15 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-msgid "form_field_type_radio"
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
  msgstr ""
  "Project-Id-Version: Plone\n"
- "POT-Creation-Date: 2021-08-03T07:34:46.833Z\n"
+ "POT-Creation-Date: 2021-08-07T16:04:30.439Z\n"
  "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
  "MIME-Version: 1.0\n"
@@ -140,7 +140,7 @@ msgid "form_field_type_attachment"
 msgstr ""
 
 #: components/Sidebar
-# defaultMessage: Multiple choice
+# defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
@@ -155,13 +155,18 @@ msgid "form_field_type_from"
 msgstr ""
 
 #: components/Sidebar
-# defaultMessage: Single choice
-msgid "form_field_type_radio"
+# defaultMessage: Multiple choice
+msgid "form_field_type_multiple_choice"
 msgstr ""
 
 #: components/Sidebar
 # defaultMessage: List
 msgid "form_field_type_select"
+msgstr ""
+
+#: components/Sidebar
+# defaultMessage: Single choice
+msgid "form_field_type_single_choice"
 msgstr ""
 
 #: components/Sidebar

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -85,8 +85,8 @@ const Field = ({
           name={name}
           title={label}
           description={description}
-          getVocabulary={() => { }}
-          getVocabularyTokenTitle={() => { }}
+          getVocabulary={() => {}}
+          getVocabularyTokenTitle={() => {}}
           choices={[...(input_values?.map((v) => [v, v]) ?? [])]}
           value={value}
           onChange={onChange}

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -6,9 +6,10 @@ import TextareaWidget from '@plone/volto/components/manage/Widgets/TextareaWidge
 import SelectWidget from '@plone/volto/components/manage/Widgets/SelectWidget';
 import EmailWidget from '@plone/volto/components/manage/Widgets/EmailWidget';
 import FileWidget from '@plone/volto/components/manage/Widgets/FileWidget';
+import CheckboxWidget from '@plone/volto/components/manage/Widgets/CheckboxWidget';
 import { DatetimeWidget } from '@plone/volto/components';
 
-import CheckboxWidget from './Widget/CheckboxWidget';
+import CheckboxListWidget from './Widget/CheckboxListWidget';
 import RadioWidget from './Widget/RadioWidget';
 
 import './Field.css';
@@ -84,8 +85,8 @@ const Field = ({
           name={name}
           title={label}
           description={description}
-          getVocabulary={() => {}}
-          getVocabularyTokenTitle={() => {}}
+          getVocabulary={() => { }}
+          getVocabularyTokenTitle={() => { }}
           choices={[...(input_values?.map((v) => [v, v]) ?? [])]}
           value={value}
           onChange={onChange}
@@ -97,9 +98,26 @@ const Field = ({
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
         />
       )}
-      {field_type === 'radio' && (
+      {field_type === 'single_choice' && (
         <RadioWidget
           id={name}
+          title={label}
+          description={description}
+          required={required}
+          onChange={onChange}
+          valueList={[
+            ...(input_values?.map((v) => ({ value: v, label: v })) ?? []),
+          ]}
+          value={value}
+          isDisabled={disabled}
+          invalid={isInvalid().toString()}
+          {...(isInvalid() ? { className: 'is-invalid' } : {})}
+        />
+      )}
+      {field_type === 'multiple_choice' && (
+        <CheckboxListWidget
+          id={name}
+          name={name}
           title={label}
           description={description}
           required={required}
@@ -121,10 +139,7 @@ const Field = ({
           description={description}
           required={required}
           onChange={onChange}
-          valueList={[
-            ...(input_values?.map((v) => ({ value: v, label: v })) ?? []),
-          ]}
-          value={value}
+          value={!!value}
           isDisabled={disabled}
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -86,13 +86,17 @@ const messages = defineMessages({
     id: 'form_field_type_select',
     defaultMessage: 'List',
   },
-  field_type_radio: {
-    id: 'form_field_type_radio',
+  field_type_single_choice: {
+    id: 'form_field_type_single_choice',
     defaultMessage: 'Single choice',
+  },
+  field_type_multiple_choice: {
+    id: 'form_field_type_multiple_choice',
+    defaultMessage: 'Multiple choice',
   },
   field_type_checkbox: {
     id: 'form_field_type_checkbox',
-    defaultMessage: 'Multiple choice',
+    defaultMessage: 'Checkbox',
   },
   field_type_date: {
     id: 'form_field_type_date',
@@ -398,8 +402,8 @@ const Sidebar = ({
                     {selected === index ? (
                       <Icon name={upSVG} size="20px" />
                     ) : (
-                      <Icon name={downSVG} size="20px" />
-                    )}
+                        <Icon name={downSVG} size="20px" />
+                      )}
                   </Accordion.Title>
                   <Accordion.Content active={selected === index}>
                     <TextWidget
@@ -434,7 +438,7 @@ const Sidebar = ({
                       onChange={(name, value) => {
                         var update_values = {};
                         if (
-                          ['select', 'radio', 'checkbox'].indexOf(value) < 0
+                          ['select', 'single_choice', 'multiple_choice'].indexOf(value) < 0
                         ) {
                           update_values.input_values = null;
                         }
@@ -455,8 +459,12 @@ const Sidebar = ({
                           intl.formatMessage(messages.field_type_select),
                         ],
                         [
-                          'radio',
-                          intl.formatMessage(messages.field_type_radio),
+                          'single_choice',
+                          intl.formatMessage(messages.field_type_single_choice),
+                        ],
+                        [
+                          'multiple_choice',
+                          intl.formatMessage(messages.field_type_multiple_choice),
                         ],
                         [
                           'checkbox',
@@ -484,22 +492,22 @@ const Sidebar = ({
                       </FormFieldWrapper>
                     )}
 
-                    {['select', 'radio', 'checkbox'].indexOf(
+                    {['select', 'single_choice', 'multiple_choice'].indexOf(
                       subblock.field_type,
                     ) >= 0 && (
-                      <ArrayWidget
-                        id="input_values"
-                        title={intl.formatMessage(messages.field_input_values)}
-                        onChange={(name, value) => {
-                          onChangeSubBlock(index, {
-                            ...subblock,
-                            [name]: value,
-                          });
-                        }}
-                        required={true}
-                        value={subblock.input_values}
-                      />
-                    )}
+                        <ArrayWidget
+                          id="input_values"
+                          title={intl.formatMessage(messages.field_input_values)}
+                          onChange={(name, value) => {
+                            onChangeSubBlock(index, {
+                              ...subblock,
+                              [name]: value,
+                            });
+                          }}
+                          required={true}
+                          value={subblock.input_values}
+                        />
+                      )}
 
                     {subblock.field_type === 'from' && (
                       <CheckboxWidget

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -402,8 +402,8 @@ const Sidebar = ({
                     {selected === index ? (
                       <Icon name={upSVG} size="20px" />
                     ) : (
-                        <Icon name={downSVG} size="20px" />
-                      )}
+                      <Icon name={downSVG} size="20px" />
+                    )}
                   </Accordion.Title>
                   <Accordion.Content active={selected === index}>
                     <TextWidget
@@ -438,7 +438,11 @@ const Sidebar = ({
                       onChange={(name, value) => {
                         var update_values = {};
                         if (
-                          ['select', 'single_choice', 'multiple_choice'].indexOf(value) < 0
+                          [
+                            'select',
+                            'single_choice',
+                            'multiple_choice',
+                          ].indexOf(value) < 0
                         ) {
                           update_values.input_values = null;
                         }
@@ -464,7 +468,9 @@ const Sidebar = ({
                         ],
                         [
                           'multiple_choice',
-                          intl.formatMessage(messages.field_type_multiple_choice),
+                          intl.formatMessage(
+                            messages.field_type_multiple_choice,
+                          ),
                         ],
                         [
                           'checkbox',
@@ -495,19 +501,19 @@ const Sidebar = ({
                     {['select', 'single_choice', 'multiple_choice'].indexOf(
                       subblock.field_type,
                     ) >= 0 && (
-                        <ArrayWidget
-                          id="input_values"
-                          title={intl.formatMessage(messages.field_input_values)}
-                          onChange={(name, value) => {
-                            onChangeSubBlock(index, {
-                              ...subblock,
-                              [name]: value,
-                            });
-                          }}
-                          required={true}
-                          value={subblock.input_values}
-                        />
-                      )}
+                      <ArrayWidget
+                        id="input_values"
+                        title={intl.formatMessage(messages.field_input_values)}
+                        onChange={(name, value) => {
+                          onChangeSubBlock(index, {
+                            ...subblock,
+                            [name]: value,
+                          });
+                        }}
+                        required={true}
+                        value={subblock.input_values}
+                      />
+                    )}
 
                     {subblock.field_type === 'from' && (
                       <CheckboxWidget

--- a/src/components/Widget/CheckboxListWidget.css
+++ b/src/components/Widget/CheckboxListWidget.css
@@ -1,0 +1,3 @@
+.checkbox-list-widget .checkbox-item {
+  margin: 0.5rem 0;
+}

--- a/src/components/Widget/CheckboxListWidget.jsx
+++ b/src/components/Widget/CheckboxListWidget.jsx
@@ -8,14 +8,14 @@ import PropTypes from 'prop-types';
 import { Checkbox } from 'semantic-ui-react';
 import { FormFieldWrapper } from '@plone/volto/components';
 
-import './CheckboxWidget.css';
+import './CheckboxListWidget.css';
 
 /**
- * CheckboxWidget component class.
+ * CheckboxListWidget component class.
  * @function CheckboxWidget
  * @returns {string} Markup of the component.
  */
-const CheckboxWidget = ({
+const CheckboxListWidget = ({
   id,
   title,
   required,
@@ -46,7 +46,7 @@ const CheckboxWidget = ({
       fieldSet={fieldSet}
       wrapped={wrapped}
     >
-      <div className="checkbox-widget">
+      <div className="checkbox-list-widget">
         {valueList?.map((opt) => (
           <div className="checkbox-item" key={opt.value}>
             <Checkbox
@@ -72,7 +72,7 @@ const CheckboxWidget = ({
  * @property {Object} propTypes Property types.
  * @static
  */
-CheckboxWidget.propTypes = {
+CheckboxListWidget.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
@@ -86,7 +86,7 @@ CheckboxWidget.propTypes = {
  * @property {Object} defaultProps Default properties.
  * @static
  */
-CheckboxWidget.defaultProps = {
+CheckboxListWidget.defaultProps = {
   description: null,
   required: false,
   error: [],
@@ -96,4 +96,4 @@ CheckboxWidget.defaultProps = {
   onDelete: null,
 };
 
-export default CheckboxWidget;
+export default CheckboxListWidget;

--- a/src/components/Widget/CheckboxWidget.css
+++ b/src/components/Widget/CheckboxWidget.css
@@ -1,3 +1,0 @@
-.checkbox-widget .checkbox-item {
-  margin: 0.5rem 0;
-}


### PR DESCRIPTION
Fixes #1 

**BREAKING CHANGE**

Renames `checkbox` field to `multiple_choice`
Renames `radio` field to `single_choice`
Adds `checkbox` as a single confirmation checkbox.

![Screenshot 2021-08-07 at 18-23-34 Sito](https://user-images.githubusercontent.com/21101435/128606957-6632faeb-dbd5-40e7-a589-ca0577169c24.png)

