### PR TITLE
Customizable schema from configuration

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,9 +46,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -56,17 +61,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -97,87 +97,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -192,7 +187,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -202,12 +197,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -217,32 +212,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -31,20 +31,25 @@ msgstr "Errore"
 msgid "Form"
 msgstr "Form"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
 msgstr "Description"
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
+msgstr ""
 
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "Form successfully submitted"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "Attached file will be sent via email, but not stored"
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -56,17 +61,12 @@ msgstr "Clear data"
 msgid "form_confirmClearData"
 msgstr "Are you sure you want to delete all saved items?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Default sender"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "This address will be used as the sender of the email with the form data"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Mail subject"
@@ -97,87 +97,82 @@ msgstr "Enter a field of type 'Sender E-mail'. If it is not present, or it is pr
 msgid "form_empty_values_validation"
 msgstr "Fill in the required fields"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Description"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Possible values"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Label"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Name"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "The name must contain spaces, and can only contain alphanumeric characters in addition to the '-' and '_' characters. The name is the same as the name of the parameter."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Required"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Field type"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Attachment"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Checkbox"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Date"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Multiple choice"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "List"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Single choice"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Static text"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Text"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Textarea"
@@ -192,7 +187,7 @@ msgstr "{formDataCount} item(s) stored"
 msgid "form_reset"
 msgstr "Clear"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Store compiled data"
@@ -202,12 +197,12 @@ msgstr "Store compiled data"
 msgid "form_select_a_value"
 msgstr "Select a value"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Send email to recipient"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Submit button label"
@@ -217,32 +212,32 @@ msgstr "Submit button label"
 msgid "form_submit_success"
 msgstr "Sent!"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Recipients"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr "Use as 'reply to'"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr "If selected, this will be the address the receiver can use to reply."
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr "Invisible captcha"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr "See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr "Title"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -33,20 +33,25 @@ msgstr "Error"
 msgid "Form"
 msgstr "Formulario"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
 msgstr "Descripción"
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
+msgstr ""
 
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "El formulario se ha enviado correctamente"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "El archivo adjunto se enviará por correo electrónico pero no se almacenará"
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -58,17 +63,12 @@ msgstr "Borrar datos"
 msgid "form_confirmClearData"
 msgstr "¿Está seguro de que quiere borrar todos los datos guardados?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Remitente por defecto"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "Esta dirección se utilizará como remitente de los mensajes enviados con los datos del formulario"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Asunto"
@@ -99,87 +99,82 @@ msgstr "Introduzca un campo de tipo 'Correo electrónico del remitente'. Si no e
 msgid "form_empty_values_validation"
 msgstr "Rellene todos los campos requeridos"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Descripción"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valores posibles"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etiqueta"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Nombre"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "El nombre puede contener espacios y solo caracteres alfanuméricos, "-" y "_". El nombre será el mismo que el parámetro."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obligatorio"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Tipo de campo"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Adjunto"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Cuadro de selección"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Fecha"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "Correo electrónico"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Selección múltiple"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Lista"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Selección única"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Texto estático"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Texto"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Campo de texto"
@@ -194,7 +189,7 @@ msgstr "{formDataCount} elemento(s) guardados"
 msgid "form_reset"
 msgstr "Borrar"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Guardar datos recopilados"
@@ -204,12 +199,12 @@ msgstr "Guardar datos recopilados"
 msgid "form_select_a_value"
 msgstr "Seleccione un valor"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar correo electrónico al receptor"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Etiqueta del botón de envío"
@@ -219,32 +214,32 @@ msgstr "Etiqueta del botón de envío"
 msgid "form_submit_success"
 msgstr "Enviado"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Receptores"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'Responder a'"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr "Si está seleccionado el valor de este campo se utilizará como cabecera 'Responder A' en el correo electrónico enviado al receptor"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr "Captcha invisible"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr "Ver https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr "Título"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -33,20 +33,25 @@ msgstr "Errorea"
 msgid "Form"
 msgstr "Formularioa"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
 msgstr "Deskribapena"
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
+msgstr ""
 
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "Formularioa ondo bidali da"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "Atxikitutako fitxategia posta elektronikoz bidaliko da baina ez da inon gordeko"
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -58,17 +63,12 @@ msgstr "Garbitu datuak"
 msgid "form_confirmClearData"
 msgstr "Ziur zaude mezu guztiak ezabatu nahi dituzula?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Defektuzko bidaltzailea"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "Helbide hau formularioaren datuak dituen posta elektronikoaren bidaltzaile gisa erabiliko da"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Mezuaren gaia"
@@ -99,87 +99,82 @@ msgstr "'Bidaltzailearen posta elektronikoa' motako eremu bat gehitu. Ez baduzu 
 msgid "form_empty_values_validation"
 msgstr "Bete derrigorrezko eremuak"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Deskribapena"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Balio posibleak"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etiketa"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Izena"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "Izenak espazioak izan behar ditu eta karaktere alfabetikoak, "-" eta "_" onartzen ditu bakarrik. Izena parametroaren izena ezartzeko erabiliko da."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Beharrezkoa"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Eremu-mota"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Fitxategia"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Aukeraketa-kutxa"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Data"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "Posta elektronikoa"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Aukeraketa anitza"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Zerrenda"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Aukeraketa bakarreko kutxa"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Testu estatikoa"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Testua"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Testua"
@@ -194,7 +189,7 @@ msgstr "Gordetako elementu kopurua: {formDataCount}"
 msgid "form_reset"
 msgstr "Garbitu"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Gorde jasotako datuak"
@@ -204,12 +199,12 @@ msgstr "Gorde jasotako datuak"
 msgid "form_select_a_value"
 msgstr "Aukeratu balio bat"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Bidali posta elektronikoa jasotzaileari"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Bidalketa botoiaren etiketa"
@@ -219,32 +214,32 @@ msgstr "Bidalketa botoiaren etiketa"
 msgid "form_submit_success"
 msgstr "Bidalita!"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Jasotzaileak"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr "Nori erantzun gisa erabili"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr "Aukeratuz gero jasotako posta elektronikoari "Erantzun" eginez gero eremu honetan adierazitako helbidera joango da erantzuna"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr "Captcha ikustezina"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr "Ikusi https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr "Izenburua"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr "Erreur"
 msgid "Form"
 msgstr "Formulaire"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,10 +46,10 @@ msgstr ""
 msgid "formSubmitted"
 msgstr "Formulaire soumis avec succès"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "Le fichier joint sera envoyé par e-mail, mais pas stocké"
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -56,17 +61,12 @@ msgstr "Effacer les données"
 msgid "form_confirmClearData"
 msgstr "Voulez-vous vraiment supprimer tous les éléments enregistrés?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Expéditeur par défaut"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "Cette adresse sera utilisée comme expéditeur de l'e-mail avec les données du formulaire"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Objet du courrier"
@@ -97,87 +97,82 @@ msgstr "Entrez un champ de type "E-mail de l'expéditeur". S'il n'est pas prése
 msgid "form_empty_values_validation"
 msgstr "Remplissez les champs obligatoires"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Description"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valeurs possibles"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Étiqueter"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Nom"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "Le nom doit contenir des espaces et ne peut contenir que des caractères alphanumériques en plus des caractères «-» et «_». Le nom est le même que le nom du paramètre."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obligatoire"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Type de champ"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Attachement"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Choix multiple"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Date"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Lister"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Texte"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Zone de texte"
@@ -192,7 +187,7 @@ msgstr "{formDataCount} article(s) stocké(s)"
 msgid "form_reset"
 msgstr "Dégager"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Stocker les données compilées"
@@ -202,12 +197,12 @@ msgstr "Stocker les données compilées"
 msgid "form_select_a_value"
 msgstr "Sélectionnez une valeur"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Envoyer un e-mail au destinataire"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Soumettre l'étiquette du bouton"
@@ -217,32 +212,32 @@ msgstr "Soumettre l'étiquette du bouton"
 msgid "form_submit_success"
 msgstr "Expédié!"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Bénéficiaires"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -31,20 +31,25 @@ msgstr "Errore"
 msgid "Form"
 msgstr "Form"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
 msgstr "Descrizione"
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
+msgstr ""
 
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "Form invato correttamente"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "Evenutali allegati potranno essere inviati per email, ma non verranno salvati."
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -56,17 +61,12 @@ msgstr "Pulisci dati"
 msgid "form_confirmClearData"
 msgstr "Confermi di voler eliminare tutti i dati salvati?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Mittente di default"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "Questo indirizzo verrà utilizzato come mittente della mail con i dati del form"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Oggetto della mail"
@@ -97,87 +97,82 @@ msgstr "Inserire un campo di tipo 'E-mail mittente'. Se non è presente, oppure 
 msgid "form_empty_values_validation"
 msgstr "Compila i campi richiesti"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Descrizione"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valori possibili"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etichetta"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Name"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "Il nome deve contenere spazi, e può contenere solo caratteri alfanumerici oltre ai caratteri '-' e '_'. Il nome coincide con il nome del parametro."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obbligatorio"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Tipo di campo"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Allegato"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr "Evenutali allegati potranno essere inviati per email, ma non verranno salvati."
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Checkbox"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Data"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Scelta multipla"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Lista"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Scelta singola"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Testo statico"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Testo"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Area di testo"
@@ -192,7 +187,7 @@ msgstr "{formDataCount} elementi salvati"
 msgid "form_reset"
 msgstr "Indietro"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Salva i dati compilati"
@@ -202,12 +197,12 @@ msgstr "Salva i dati compilati"
 msgid "form_select_a_value"
 msgstr "Seleziona un valore"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Invia email al destinatario"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Testo sul bottone di invio"
@@ -217,32 +212,32 @@ msgstr "Testo sul bottone di invio"
 msgid "form_submit_success"
 msgstr "Inviato!"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Destinatari"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr "Usa come 'reply to'"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr "Se selezionato, questo sarà l'indirizzo a cui il destinatario potrà rispondere."
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr "Captcha invisibile"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr "Leggi https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr "Titolo"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,9 +46,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -56,17 +61,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -97,87 +97,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -192,7 +187,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -202,12 +197,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -217,32 +212,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,9 +46,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -56,17 +61,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -97,87 +97,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -192,7 +187,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -202,12 +197,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -217,32 +212,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,9 +46,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -56,17 +61,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -97,87 +97,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -192,7 +187,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -202,12 +197,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -217,32 +212,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -37,20 +37,25 @@ msgstr "Erro"
 msgid "Form"
 msgstr "Formulário"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
 msgstr "descrição"
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
+msgstr ""
 
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "Formulário enviado com sucesso"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
-msgstr "O arquivo anexado será enviado por e-mail, mas não armazenado"
+msgid "form_attachment_send_email_info_text"
+msgstr ""
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -62,17 +67,12 @@ msgstr "Limpar dados"
 msgid "form_confirmClearData"
 msgstr "Você tem certeza que deseja apagar todos as respostas salvas?"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Remetente padrão"
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr "Este endereço será utilizado como o remetente do e-mail com os dados do formulário"
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Assunto do e-mail"
@@ -103,87 +103,82 @@ msgstr "Digite um campo do tipo 'E-mail do remetente'. Se não estiver presente,
 msgid "form_empty_values_validation"
 msgstr "Por favor preencha os campos obrigatórios"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr "Descrição"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valores possíveis"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etiqueta"
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr "Nome"
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr "O nome deve conter espaços e só pode conter caracteres alfanuméricos além dos caracteres '-' e '_'. O nome é igual ao nome do parâmetro."
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obrigatório"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Tipo de campo"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Anexo"
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Múltipla escolha"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Data"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Múltipla escolha"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Opções"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Escolha única"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Texto estático"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Texto"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Área de texto"
@@ -198,7 +193,7 @@ msgstr "{formDataCount} item(ns) armazenados"
 msgid "form_reset"
 msgstr "Limpar"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Armazenar dados"
@@ -208,12 +203,12 @@ msgstr "Armazenar dados"
 msgid "form_select_a_value"
 msgstr "Selecione um valor"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar e-mail para o destinatário"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Texto do botão de enviar"
@@ -223,32 +218,32 @@ msgstr "Texto do botão de enviar"
 msgid "form_submit_success"
 msgstr "Enviado!"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr "Destinatários"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'responder para'"
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr "Usar este campo como valor do cabeçalho de 'responder para'"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr "Captcha invisível"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr "Leia mais em https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode"
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr "título"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -31,9 +31,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -41,9 +46,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -56,17 +61,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -97,87 +97,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -192,7 +187,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -202,12 +197,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -217,32 +212,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-10-23T14:57:54.656Z\n"
+"POT-Creation-Date: 2022-01-17T15:37:37.006Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -33,9 +33,14 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Description
 msgid "description"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Form
+msgid "form"
 msgstr ""
 
 #: components/View
@@ -43,9 +48,9 @@ msgstr ""
 msgid "formSubmitted"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
-msgid "form_attachment_info_text"
+msgid "form_attachment_send_email_info_text"
 msgstr ""
 
 #: components/Sidebar
@@ -58,17 +63,12 @@ msgstr ""
 msgid "form_confirmClearData"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Default sender
 msgid "form_default_from"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: This address will be used as the sender of the email with the form data
-msgid "form_default_from_description"
-msgstr ""
-
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr ""
@@ -99,87 +99,82 @@ msgstr ""
 msgid "form_empty_values_validation"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Description
 msgid "form_field_description"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Label
 msgid "form_field_label"
 msgstr ""
 
-#: components/Sidebar
-# defaultMessage: Name
-msgid "form_field_name"
-msgstr ""
-
-#: components/Sidebar
-# defaultMessage: The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.
-msgid "form_field_name_description"
-msgstr ""
-
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Required
 msgid "form_field_required"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Field type
 msgid "form_field_type"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
+msgid "form_field_type_attachment_info_text"
+msgstr ""
+
+#: fieldSchema
 # defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Date
 msgid "form_field_type_date"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: List
 msgid "form_field_type_select"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Text
 msgid "form_field_type_text"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr ""
@@ -194,7 +189,7 @@ msgstr ""
 msgid "form_reset"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr ""
@@ -204,12 +199,12 @@ msgstr ""
 msgid "form_select_a_value"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr ""
@@ -219,32 +214,32 @@ msgstr ""
 msgid "form_submit_success"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Recipients
 msgid "form_to"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo"
 msgstr ""
 
-#: components/Sidebar
+#: fieldSchema
 # defaultMessage: undefined
 msgid "form_useAsReplyTo_description"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Invisible captcha
 msgid "invisible_hcaptcha"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode
 msgid "invisible_hcaptcha_desc"
 msgstr ""
 
-#: components/Sidebar
+#: formSchema
 # defaultMessage: Title
 msgid "title"
 msgstr ""

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -13,6 +13,7 @@ import Field from 'volto-form-block/components/Field';
 import GoogleReCaptchaWidget from 'volto-form-block/components/Widget/GoogleReCaptchaWidget';
 import HCaptchaWidget from 'volto-form-block/components/Widget/HCaptchaWidget';
 import './FormView.css';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   default_submit_label: {
@@ -66,6 +67,14 @@ const FormView = ({
     return formErrors?.indexOf(field) < 0;
   };
 
+  var FieldSchema = config.blocks.blocksConfig.form.fieldSchema;
+  var fieldSchemaProperties = FieldSchema()?.properties;
+  var fields_to_send = [];
+  for (var key in fieldSchemaProperties) {
+    if (fieldSchemaProperties[key].send_to_backend) {
+      fields_to_send.push(key);
+    }
+  }
   return (
     <div className="block form">
       <div className="public-ui">
@@ -120,7 +129,12 @@ const FormView = ({
                 ))}
                 {data.subblocks?.map((subblock, index) => {
                   let name = getFieldName(subblock.label, subblock.id);
-
+                  var fields_to_send_with_value = Object.assign(
+                    {},
+                    ...fields_to_send.map((field) => {
+                      return { [field]: subblock[field] };
+                    }),
+                  );
                   return (
                     <Grid.Row key={'row' + index}>
                       <Grid.Column>
@@ -132,7 +146,7 @@ const FormView = ({
                               subblock.id,
                               field,
                               value,
-                              subblock.label,
+                              fields_to_send_with_value,
                             )
                           }
                           value={

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -71,7 +71,8 @@ const FormView = ({
   var fieldSchemaProperties = FieldSchema()?.properties;
   var fields_to_send = [];
   for (var key in fieldSchemaProperties) {
-    if (fieldSchemaProperties[key].send_to_backend) {
+    if (fieldSchemaProperties[key].send_to_backend ?? true) {
+      //send by default
       fields_to_send.push(key);
     }
   }
@@ -132,9 +133,13 @@ const FormView = ({
                   var fields_to_send_with_value = Object.assign(
                     {},
                     ...fields_to_send.map((field) => {
-                      return { [field]: subblock[field] };
+                      return {
+                        [field]: subblock[field],
+                        label: subblock.label,
+                      };
                     }),
                   );
+
                   return (
                     <Grid.Row key={'row' + index}>
                       <Grid.Column>

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -72,7 +72,6 @@ const FormView = ({
   var fields_to_send = [];
   for (var key in fieldSchemaProperties) {
     if (fieldSchemaProperties[key].send_to_backend) {
-      //send by default
       fields_to_send.push(key);
     }
   }

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -71,7 +71,7 @@ const FormView = ({
   var fieldSchemaProperties = FieldSchema()?.properties;
   var fields_to_send = [];
   for (var key in fieldSchemaProperties) {
-    if (fieldSchemaProperties[key].send_to_backend ?? true) {
+    if (fieldSchemaProperties[key].send_to_backend) {
       //send by default
       fields_to_send.push(key);
     }
@@ -135,7 +135,6 @@ const FormView = ({
                     ...fields_to_send.map((field) => {
                       return {
                         [field]: subblock[field],
-                        label: subblock.label,
                       };
                     }),
                   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -185,15 +185,7 @@ const Sidebar = ({
                       schema={FieldSchema(subblock)}
                       onChangeField={(name, value) => {
                         var update_values = {};
-                        if (
-                          [
-                            'select',
-                            'single_choice',
-                            'multiple_choice',
-                          ].indexOf(value) < 0
-                        ) {
-                          update_values.input_values = null;
-                        }
+
                         onChangeSubBlock(index, {
                           ...subblock,
                           [name]: value,

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,15 +13,7 @@ import {
 } from 'semantic-ui-react';
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
-import {
-  Icon,
-  TextWidget,
-  CheckboxWidget,
-  SelectWidget,
-  ArrayWidget,
-  FormFieldWrapper,
-  TextareaWidget,
-} from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
 
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
@@ -32,122 +24,9 @@ import { getFormData, exportCsvFormData, clearFormData } from '../actions';
 
 import config from '@plone/volto/registry';
 
+import { BlockDataForm } from '@plone/volto/components';
+
 const messages = defineMessages({
-  title: {
-    id: 'title',
-    defaultMessage: 'Title',
-  },
-  description: {
-    id: 'description',
-    defaultMessage: 'Description',
-  },
-  default_to: {
-    id: 'form_to',
-    defaultMessage: 'Recipients',
-  },
-  submit_label: {
-    id: 'form_submit_label',
-    defaultMessage: 'Submit button label',
-  },
-  invisibleHCaptcha: {
-    id: 'invisible_hcaptcha',
-    defaultMessage: 'Invisible captcha',
-  },
-  invisibleHCaptchaDescription: {
-    id: 'invisible_hcaptcha_desc',
-    defaultMessage:
-      'See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode',
-  },
-  field_label: {
-    id: 'form_field_label',
-    defaultMessage: 'Label',
-  },
-  field_description: {
-    id: 'form_field_description',
-    defaultMessage: 'Description',
-  },
-  field_name: {
-    id: 'form_field_name',
-    defaultMessage: 'Name',
-  },
-  field_name_description: {
-    id: 'form_field_name_description',
-    defaultMessage:
-      'The name must contain spaces, and can only contain alphanumeric characters in addition to the "-" and "_" characters. The name is the same as the name of the parameter.',
-  },
-  field_required: {
-    id: 'form_field_required',
-    defaultMessage: 'Required',
-  },
-  field_type: {
-    id: 'form_field_type',
-    defaultMessage: 'Field type',
-  },
-  field_type_text: {
-    id: 'form_field_type_text',
-    defaultMessage: 'Text',
-  },
-  field_type_textarea: {
-    id: 'form_field_type_textarea',
-    defaultMessage: 'Textarea',
-  },
-  field_type_select: {
-    id: 'form_field_type_select',
-    defaultMessage: 'List',
-  },
-  field_type_single_choice: {
-    id: 'form_field_type_single_choice',
-    defaultMessage: 'Single choice',
-  },
-  field_type_multiple_choice: {
-    id: 'form_field_type_multiple_choice',
-    defaultMessage: 'Multiple choice',
-  },
-  field_type_checkbox: {
-    id: 'form_field_type_checkbox',
-    defaultMessage: 'Checkbox',
-  },
-  field_type_date: {
-    id: 'form_field_type_date',
-    defaultMessage: 'Date',
-  },
-  field_type_attachment: {
-    id: 'form_field_type_attachment',
-    defaultMessage: 'Attachment',
-  },
-  field_type_from: {
-    id: 'form_field_type_from',
-    defaultMessage: 'E-mail',
-  },
-  field_type_static_text: {
-    id: 'form_field_type_static_text',
-    defaultMessage: 'Static text',
-  },
-  field_input_values: {
-    id: 'form_field_input_values',
-    defaultMessage: 'Possible values',
-  },
-  default_subject: {
-    id: 'form_default_subject',
-    defaultMessage: 'Mail subject',
-  },
-  default_from: {
-    id: 'form_default_from',
-    defaultMessage: 'Default sender',
-  },
-  default_from_description: {
-    id: 'form_default_from_description',
-    defaultMessage:
-      'This address will be used as the sender of the email with the form data',
-  },
-  store: {
-    id: 'form_save_persistent_data',
-    defaultMessage: 'Store compiled data',
-  },
-  send: {
-    id: 'form_send_email',
-    defaultMessage: 'Send email to recipient',
-  },
   exportCsv: {
     id: 'form_edit_exportCsv',
     defaultMessage: 'Export data',
@@ -167,19 +46,6 @@ const messages = defineMessages({
   cancel: {
     id: 'Cancel',
     defaultMessage: 'Cancel',
-  },
-  attachmentInfoText: {
-    id: 'form_attachment_info_text',
-    defaultMessage: 'Attached file will be sent via email, but not stored',
-  },
-  useAsReplyTo: {
-    id: 'form_useAsReplyTo',
-    defineMessages: "Use as 'reply to'",
-  },
-  useAsReplyTo_description: {
-    id: 'form_useAsReplyTo_description',
-    defineMessages:
-      'If selected, this will be the address the receiver can use to reply.',
   },
 });
 
@@ -211,7 +77,8 @@ const Sidebar = ({
     data.subblocks.forEach((subblock) => {
       subblock.field_id = subblock.id;
     });
-
+  var FormSchema = config.blocks.blocksConfig.form.formSchema;
+  var FieldSchema = config.blocks.blocksConfig.form.fieldSchema;
   return (
     <Form>
       <Segment.Group raised>
@@ -221,139 +88,16 @@ const Sidebar = ({
           </h2>
         </header>
         <Segment>
-          <TextWidget
-            id="title"
-            title={intl.formatMessage(messages.title)}
-            required={false}
-            value={data.title}
-            onChange={(name, value) => {
+          <BlockDataForm
+            schema={FormSchema(data)}
+            onChangeField={(id, value) => {
               onChangeBlock(block, {
                 ...data,
-                [name]: value,
+                [id]: value,
               });
             }}
+            formData={data}
           />
-          <TextareaWidget
-            id="description"
-            title={intl.formatMessage(messages.description)}
-            required={false}
-            value={data.description}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-          <TextWidget
-            id="default_to"
-            title={intl.formatMessage(messages.default_to)}
-            required={true}
-            value={data.default_to}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-          <TextWidget
-            id="default_from"
-            title={intl.formatMessage(messages.default_from)}
-            description={intl.formatMessage(messages.default_from_description)}
-            required={true}
-            value={data.default_from}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-
-          <TextWidget
-            id="default_subject"
-            title={intl.formatMessage(messages.default_subject)}
-            required={true}
-            value={data.default_subject}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-          <TextWidget
-            id="submit_label"
-            title={intl.formatMessage(messages.submit_label)}
-            required={false}
-            value={data.submit_label}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-
-          {process.env.RAZZLE_HCAPTCHA_KEY && (
-            <CheckboxWidget
-              id="invisibleHCaptcha"
-              title={intl.formatMessage(messages.invisibleHCaptcha)}
-              description={intl.formatMessage(
-                messages.invisibleHCaptchaDescription,
-              )}
-              required={false}
-              value={data.invisibleHCaptcha ?? false}
-              onChange={(name, value) => {
-                onChangeBlock(block, {
-                  ...data,
-                  [name]: value,
-                });
-              }}
-            />
-          )}
-
-          <CheckboxWidget
-            id="store"
-            title={intl.formatMessage(messages.store)}
-            required={false}
-            value={data.store ?? false}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-          <Form.Field inline className="help">
-            <Grid>
-              <Grid.Row stretched>
-                <Grid.Column stretched width="12">
-                  <p
-                    className="help"
-                    style={{ marginTop: '-1rem', background: '#fff' }}
-                  >
-                    {intl.formatMessage(messages.attachmentInfoText)}
-                  </p>
-                </Grid.Column>
-              </Grid.Row>
-            </Grid>
-          </Form.Field>
-
-          <CheckboxWidget
-            id="send"
-            title={intl.formatMessage(messages.send)}
-            required={false}
-            value={data.send ?? false}
-            onChange={(name, value) => {
-              onChangeBlock(block, {
-                ...data,
-                [name]: value,
-              });
-            }}
-          />
-
           {properties?.['@components']?.form_data && (
             <Form.Field inline>
               <Grid>
@@ -437,36 +181,9 @@ const Sidebar = ({
                     )}
                   </Accordion.Title>
                   <Accordion.Content active={selected === index}>
-                    <TextWidget
-                      id="label"
-                      title={intl.formatMessage(messages.field_label)}
-                      required={true}
-                      value={subblock.label}
-                      onChange={(name, value) => {
-                        onChangeSubBlock(index, {
-                          ...subblock,
-                          [name]: value,
-                        });
-                      }}
-                    />
-                    <TextWidget
-                      id="description"
-                      title={intl.formatMessage(messages.field_description)}
-                      value={subblock.description}
-                      onChange={(name, value) => {
-                        onChangeSubBlock(index, {
-                          ...subblock,
-                          [name]: value,
-                        });
-                      }}
-                    />
-
-                    <SelectWidget
-                      id="field_type"
-                      title={intl.formatMessage(messages.field_type)}
-                      required={true}
-                      value={subblock.field_type || ''}
-                      onChange={(name, value) => {
+                    <BlockDataForm
+                      schema={FieldSchema(subblock)}
+                      onChangeField={(name, value) => {
                         var update_values = {};
                         if (
                           [
@@ -483,105 +200,7 @@ const Sidebar = ({
                           ...update_values,
                         });
                       }}
-                      choices={[
-                        ['text', intl.formatMessage(messages.field_type_text)],
-                        [
-                          'textarea',
-                          intl.formatMessage(messages.field_type_textarea),
-                        ],
-                        [
-                          'select',
-                          intl.formatMessage(messages.field_type_select),
-                        ],
-                        [
-                          'single_choice',
-                          intl.formatMessage(messages.field_type_single_choice),
-                        ],
-                        [
-                          'multiple_choice',
-                          intl.formatMessage(
-                            messages.field_type_multiple_choice,
-                          ),
-                        ],
-                        [
-                          'checkbox',
-                          intl.formatMessage(messages.field_type_checkbox),
-                        ],
-                        ['date', intl.formatMessage(messages.field_type_date)],
-                        [
-                          'attachment',
-                          intl.formatMessage(messages.field_type_attachment),
-                        ],
-                        ['from', intl.formatMessage(messages.field_type_from)],
-                        [
-                          'static_text',
-                          intl.formatMessage(messages.field_type_static_text),
-                        ],
-                        ...(config.blocks.blocksConfig.form.additionalFields?.map(
-                          (fieldType) => [fieldType.id, fieldType.label],
-                        ) ?? []),
-                      ]}
-                    />
-
-                    {subblock.field_type === 'attachment' && (
-                      <FormFieldWrapper id="attachment-info" columns={1}>
-                        <div className="wrapper">
-                          <small>
-                            {intl.formatMessage(messages.attachmentInfoText)}
-                          </small>
-                        </div>
-                      </FormFieldWrapper>
-                    )}
-
-                    {['select', 'single_choice', 'multiple_choice'].indexOf(
-                      subblock.field_type,
-                    ) >= 0 && (
-                      <ArrayWidget
-                        id="input_values"
-                        title={intl.formatMessage(messages.field_input_values)}
-                        onChange={(name, value) => {
-                          onChangeSubBlock(index, {
-                            ...subblock,
-                            [name]: value,
-                          });
-                        }}
-                        required={true}
-                        value={subblock.input_values ?? []}
-                        creatable={true}
-                      />
-                    )}
-
-                    {subblock.field_type === 'from' && (
-                      <CheckboxWidget
-                        id="use_as_reply_to"
-                        title={intl.formatMessage(messages.useAsReplyTo)}
-                        description={intl.formatMessage(
-                          messages.useAsReplyTo_description,
-                        )}
-                        value={
-                          subblock.use_as_reply_to
-                            ? subblock.use_as_reply_to
-                            : false
-                        }
-                        onChange={(name, value) => {
-                          onChangeSubBlock(index, {
-                            ...subblock,
-                            [name]: value,
-                          });
-                        }}
-                      />
-                    )}
-
-                    <CheckboxWidget
-                      id="required"
-                      title={intl.formatMessage(messages.field_required)}
-                      value={subblock.required ? subblock.required : false}
-                      onChange={(name, value) => {
-                        onChangeSubBlock(index, {
-                          ...subblock,
-                          [name]: value,
-                        });
-                      }}
+                      formData={subblock}
                     />
                   </Accordion.Content>
                 </div>

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -78,8 +78,8 @@ const View = ({ data, id, path }) => {
   const [formErrors, setFormErrors] = useState([]);
   const submitResults = useSelector((state) => state.submitForm);
 
-  const onChangeFormData = (field_id, field, value, label) => {
-    setFormData({ field, value: { field_id, value, label } });
+  const onChangeFormData = (field_id, field, value, extras) => {
+    setFormData({ field, value: { field_id, value, ...extras } });
   };
 
   useEffect(() => {

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -1,0 +1,159 @@
+import config from '@plone/volto/registry';
+import { defineMessages } from 'react-intl';
+import { useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  field_label: {
+    id: 'form_field_label',
+    defaultMessage: 'Label',
+  },
+  field_description: {
+    id: 'form_field_description',
+    defaultMessage: 'Description',
+  },
+  field_required: {
+    id: 'form_field_required',
+    defaultMessage: 'Required',
+  },
+  field_type: {
+    id: 'form_field_type',
+    defaultMessage: 'Field type',
+  },
+  field_type_text: {
+    id: 'form_field_type_text',
+    defaultMessage: 'Text',
+  },
+  field_type_textarea: {
+    id: 'form_field_type_textarea',
+    defaultMessage: 'Textarea',
+  },
+  field_type_select: {
+    id: 'form_field_type_select',
+    defaultMessage: 'List',
+  },
+  field_type_single_choice: {
+    id: 'form_field_type_single_choice',
+    defaultMessage: 'Single choice',
+  },
+  field_type_multiple_choice: {
+    id: 'form_field_type_multiple_choice',
+    defaultMessage: 'Multiple choice',
+  },
+  field_type_checkbox: {
+    id: 'form_field_type_checkbox',
+    defaultMessage: 'Checkbox',
+  },
+  field_type_date: {
+    id: 'form_field_type_date',
+    defaultMessage: 'Date',
+  },
+  field_type_attachment: {
+    id: 'form_field_type_attachment',
+    defaultMessage: 'Attachment',
+  },
+  field_type_from: {
+    id: 'form_field_type_from',
+    defaultMessage: 'E-mail',
+  },
+  field_type_static_text: {
+    id: 'form_field_type_static_text',
+    defaultMessage: 'Static text',
+  },
+  field_input_values: {
+    id: 'form_field_input_values',
+    defaultMessage: 'Possible values',
+  },
+  useAsReplyTo: {
+    id: 'form_useAsReplyTo',
+    defineMessages: "Use as 'reply to'",
+  },
+  useAsReplyTo_description: {
+    id: 'form_useAsReplyTo_description',
+    defineMessages:
+      'If selected, this will be the address the receiver can use to reply.',
+  },
+});
+
+export default (props) => {
+  var intl = useIntl();
+  const baseFieldTypeChoices = [
+    ['text', intl.formatMessage(messages.field_type_text)],
+    ['textarea', intl.formatMessage(messages.field_type_textarea)],
+    ['select', intl.formatMessage(messages.field_type_select)],
+    ['single_choice', intl.formatMessage(messages.field_type_single_choice)],
+    [
+      'multiple_choice',
+      intl.formatMessage(messages.field_type_multiple_choice),
+    ],
+    ['checkbox', intl.formatMessage(messages.field_type_checkbox)],
+    ['date', intl.formatMessage(messages.field_type_date)],
+    ['attachment', intl.formatMessage(messages.field_type_attachment)],
+    ['from', intl.formatMessage(messages.field_type_from)],
+    ['static_text', intl.formatMessage(messages.field_type_static_text)],
+  ];
+  var attachmentDescription =
+    props?.field_type === 'attachment'
+      ? { description: intl.formatMessage(messages.attachmentInfoText) }
+      : {};
+  var fieldTypeChoices = [
+    'select',
+    'single_choice',
+    'multiple_choice',
+  ].includes(props?.field_type)
+    ? ['input_values']
+    : [];
+  var useAsReplyTo = props?.field_type === 'from' ? ['use_as_reply_to'] : [];
+  return {
+    title: props?.label || '',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'label',
+          'description',
+          'field_type',
+          ...fieldTypeChoices,
+          ...useAsReplyTo,
+          'required',
+        ],
+      },
+    ],
+    properties: {
+      label: {
+        title: intl.formatMessage(messages.field_label),
+      },
+      description: {
+        title: intl.formatMessage(messages.field_description),
+      },
+      field_type: {
+        title: intl.formatMessage(messages.field_type),
+        type: 'array',
+        choices: [
+          ...baseFieldTypeChoices,
+          ...(config.blocks.blocksConfig.form.additionalFields?.map(
+            (fieldType) => [fieldType.id, fieldType.label],
+          ) ?? []),
+        ],
+        ...attachmentDescription,
+      },
+      input_values: {
+        title: intl.formatMessage(messages.field_input_values),
+        type: 'array',
+        creatable: true,
+      },
+      use_as_reply_to: {
+        title: intl.formatMessage(messages.useAsReplyTo),
+        description: intl.formatMessage(messages.useAsReplyTo_description),
+        type: 'boolean',
+        default: false,
+      },
+      required: {
+        title: intl.formatMessage(messages.field_required),
+        type: 'boolean',
+        default: false,
+      },
+    },
+    required: ['label', 'field_type', 'input_values', ...fieldTypeChoices],
+  };
+};

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -122,6 +122,7 @@ export default (props) => {
     properties: {
       label: {
         title: intl.formatMessage(messages.field_label),
+        send_to_backend: true,
       },
       description: {
         title: intl.formatMessage(messages.field_description),

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -51,6 +51,10 @@ const messages = defineMessages({
     id: 'form_field_type_attachment',
     defaultMessage: 'Attachment',
   },
+  field_type_attachment_info_text: {
+    id: 'form_field_type_attachment_info_text',
+    defaultMessage: 'Any attachments can be emailed, but will not be saved.',
+  },
   field_type_from: {
     id: 'form_field_type_from',
     defaultMessage: 'E-mail',
@@ -93,7 +97,11 @@ export default (props) => {
   ];
   var attachmentDescription =
     props?.field_type === 'attachment'
-      ? { description: intl.formatMessage(messages.attachmentInfoText) }
+      ? {
+          description: intl.formatMessage(
+            messages.field_type_attachment_info_text,
+          ),
+        }
       : {};
   var fieldTypeChoices = [
     'select',

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -43,8 +43,8 @@ const messages = defineMessages({
     id: 'form_save_persistent_data',
     defaultMessage: 'Store compiled data',
   },
-  attachmentInfoText: {
-    id: 'form_attachment_info_text',
+  attachmentSendEmail: {
+    id: 'form_attachment_send_email_info_text',
     defaultMessage: 'Attached file will be sent via email, but not stored',
   },
   send: {
@@ -105,7 +105,7 @@ export default () => {
       store: {
         type: 'boolean',
         title: intl.formatMessage(messages.store),
-        description: intl.formatMessage(messages.attachmentInfoText),
+        description: intl.formatMessage(messages.attachmentSendEmail),
       },
       send: {
         type: 'boolean',

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -1,0 +1,117 @@
+import { defineMessages } from 'react-intl';
+import { useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  form: {
+    id: 'form',
+    defaultMessage: 'Form',
+  },
+  title: {
+    id: 'title',
+    defaultMessage: 'Title',
+  },
+  description: {
+    id: 'description',
+    defaultMessage: 'Description',
+  },
+  default_to: {
+    id: 'form_to',
+    defaultMessage: 'Recipients',
+  },
+  default_from: {
+    id: 'form_default_from',
+    defaultMessage: 'Default sender',
+  },
+  default_subject: {
+    id: 'form_default_subject',
+    defaultMessage: 'Mail subject',
+  },
+  submit_label: {
+    id: 'form_submit_label',
+    defaultMessage: 'Submit button label',
+  },
+  invisibleHCaptcha: {
+    id: 'invisible_hcaptcha',
+    defaultMessage: 'Invisible captcha',
+  },
+  invisibleHCaptchaDescription: {
+    id: 'invisible_hcaptcha_desc',
+    defaultMessage:
+      'See https://docs.hcaptcha.com/faq#do-i-need-to-display-anything-on-the-page-when-using-hcaptcha-in-invisible-mode',
+  },
+  store: {
+    id: 'form_save_persistent_data',
+    defaultMessage: 'Store compiled data',
+  },
+  attachmentInfoText: {
+    id: 'form_attachment_info_text',
+    defaultMessage: 'Attached file will be sent via email, but not stored',
+  },
+  send: {
+    id: 'form_send_email',
+    defaultMessage: 'Send email to recipient',
+  },
+});
+
+export default () => {
+  var intl = useIntl();
+  var invisibleHCaptcha = process.env.RAZZLE_HCAPTCHA_KEY
+    ? ['invisibleHCaptcha']
+    : [];
+  return {
+    title: intl.formatMessage(messages.form),
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'title',
+          'description',
+          'default_to',
+          'default_from',
+          'default_subject',
+          'submit_label',
+          ...invisibleHCaptcha,
+          'store',
+          'send',
+        ],
+      },
+    ],
+    properties: {
+      title: {
+        title: intl.formatMessage(messages.title),
+      },
+      description: {
+        title: intl.formatMessage(messages.description),
+        type: 'textarea',
+      },
+      default_to: {
+        title: intl.formatMessage(messages.default_to),
+      },
+      default_from: {
+        title: intl.formatMessage(messages.default_from),
+      },
+      default_subject: {
+        title: intl.formatMessage(messages.default_subject),
+      },
+      submit_label: {
+        title: intl.formatMessage(messages.submit_label),
+      },
+      invisibleHCaptcha: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.invisibleHCaptcha),
+        description: intl.formatMessage(messages.invisibleHCaptchaDescription),
+      },
+      store: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.store),
+        description: intl.formatMessage(messages.attachmentInfoText),
+      },
+      send: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.send),
+      },
+    },
+    required: ['default_to', 'default_from', 'default_subject'],
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ import {
   exportCsvFormData,
   clearFormData,
 } from './reducers';
+import FormSchema from './formSchema';
+import FieldSchema from './fieldSchema';
 export { submitForm, getFormData, exportCsvFormData } from './actions';
 
 const applyConfig = (config) => {
@@ -27,6 +29,8 @@ const applyConfig = (config) => {
       group: 'text',
       view: View,
       edit: Edit,
+      formSchema: FormSchema,
+      fieldSchema: FieldSchema,
       additionalFields: [],
       restricted: false,
       mostUsed: true,


### PR DESCRIPTION
- Add volto default schema functionality to the sidebar
- Make Form and Field schema customizable from configuration
- Add to the fieldSchema properties the possibility to send extra information to the backend
- Send all extra defined information of each field parameter to the backend on submit