### PR TITLE
fix: set norobots captcha as required

### DIFF
--- a/src/components/Widget/NoRobotsCaptchaWidget.jsx
+++ b/src/components/Widget/NoRobotsCaptchaWidget.jsx
@@ -35,7 +35,7 @@ const NoRobotsCaptchaWidget = ({ id, id_check, title, captchaToken }) => {
             captchaToken.current = createToken(id, id_check, value);
             setValue(value);
           }}
-          // required={true}
+          required={true}
           value={value}
         />
       </Grid.Column>


### PR DESCRIPTION
When using the norobots captcha (question & answer based), the user is required to fill it, so we should mark it as required, this way the red dot of required field is shown and the user knows that she has to fill it.