### PR TITLE
Hidden field type

### DIFF
--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -12,6 +12,7 @@ import {
   TextareaWidget,
   CheckboxListWidget,
   RadioWidget,
+  HiddenWidget,
 } from 'volto-form-block/components/Widget';
 import config from '@plone/volto/registry';
 
@@ -194,6 +195,9 @@ const Field = ({
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
         />
+      )}
+      {field_type === 'hidden' && (
+        <HiddenWidget id={name} value={value} isOnEdit={isOnEdit} />
       )}
       {field_type === 'static_text' &&
         (isOnEdit ? (

--- a/src/components/FieldTypeSchemaExtenders/HiddenSchemaExtender.js
+++ b/src/components/FieldTypeSchemaExtenders/HiddenSchemaExtender.js
@@ -8,13 +8,13 @@ const messages = defineMessages({
 
 export const HiddenSchemaExtender = (intl) => {
   return {
-    fields: ['input_value'],
+    fields: ['value'],
     properties: {
-      input_value: {
+      value: {
         title: intl.formatMessage(messages.field_input_value),
         type: 'text',
       },
     },
-    required: ['input_value'],
+    required: ['value'],
   };
 };

--- a/src/components/FieldTypeSchemaExtenders/HiddenSchemaExtender.js
+++ b/src/components/FieldTypeSchemaExtenders/HiddenSchemaExtender.js
@@ -1,0 +1,20 @@
+import { defineMessages } from 'react-intl';
+const messages = defineMessages({
+  field_input_value: {
+    id: 'form_field_input_value',
+    defaultMessage: 'Value for field',
+  },
+});
+
+export const HiddenSchemaExtender = (intl) => {
+  return {
+    fields: ['input_value'],
+    properties: {
+      input_value: {
+        title: intl.formatMessage(messages.field_input_value),
+        type: 'text',
+      },
+    },
+    required: ['input_value'],
+  };
+};

--- a/src/components/FieldTypeSchemaExtenders/index.js
+++ b/src/components/FieldTypeSchemaExtenders/index.js
@@ -1,2 +1,3 @@
 export { SelectionSchemaExtender } from './SelectionSchemaExtender';
 export { FromSchemaExtender } from './FromSchemaExtender';
+export { HiddenSchemaExtender } from './HiddenSchemaExtender';

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -48,12 +48,29 @@ const formStateReducer = (state, action) => {
   }
 };
 
-const getInitialData = (data) => ({
-  ...data.reduce(
-    (acc, field) => ({ ...acc, [getFieldName(field.label, field.id)]: field }),
-    {},
-  ),
-});
+const getInitialData = (data) => {
+  const { static_fields = [], subblocks = [] } = data;
+
+  return {
+    ...subblocks.reduce(
+      (acc, field) =>
+        field.field_type === 'hidden'
+          ? {
+              ...acc,
+              [getFieldName(field.label, field.id)]: field,
+            }
+          : acc,
+      {},
+    ),
+    ...static_fields.reduce(
+      (acc, field) => ({
+        ...acc,
+        [getFieldName(field.label, field.id)]: field,
+      }),
+      {},
+    ),
+  };
+};
 
 /**
  * Form view
@@ -62,18 +79,17 @@ const getInitialData = (data) => ({
 const View = ({ data, id, path }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const { static_fields = [] } = data;
 
   const [formData, setFormData] = useReducer((state, action) => {
     if (action.reset) {
-      return getInitialData(static_fields);
+      return getInitialData(data);
     }
 
     return {
       ...state,
       [action.field]: action.value,
     };
-  }, getInitialData(static_fields));
+  }, getInitialData(data));
 
   const [formState, setFormState] = useReducer(formStateReducer, initialState);
   const [formErrors, setFormErrors] = useState([]);

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -57,7 +57,10 @@ const getInitialData = (data) => {
         field.field_type === 'hidden'
           ? {
               ...acc,
-              [getFieldName(field.label, field.id)]: field,
+              [getFieldName(field.label, field.id)]: {
+                ...field,
+                ...(data[field.id] && { custom_field_id: data[field.id] }),
+              },
             }
           : acc,
       {},

--- a/src/components/Widget/HiddenWidget.jsx
+++ b/src/components/Widget/HiddenWidget.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+
+/**
+ * Displays an `<input type="hidden" />`.
+ */
+export const HiddenWidget = ({ id, title, value, isOnEdit }) => {
+  const inputId = `field-${id}`;
+  return (
+    <>
+      {isOnEdit ? <label htmlFor={inputId}>Hidden: {title || id}</label> : null}
+      <input type="hidden" id={inputId} name={id} value={value} />
+    </>
+  );
+};
+
+HiddenWidget.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.string,
+  focus: PropTypes.bool,
+  onChange: PropTypes.func,
+  onBlur: PropTypes.func,
+  onClick: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+  minLength: PropTypes.number,
+  maxLength: PropTypes.number,
+  wrapped: PropTypes.bool,
+  placeholder: PropTypes.string,
+};

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -6,6 +6,7 @@ export { default as EmailWidget } from 'volto-form-block/components/Widget/Email
 export { default as FileWidget } from 'volto-form-block/components/Widget/FileWidget';
 export { default as GoogleReCaptchaWidget } from 'volto-form-block/components/Widget/GoogleReCaptchaWidget';
 export { default as HCaptchaWidget } from 'volto-form-block/components/Widget/HCaptchaWidget';
+export { HiddenWidget } from 'volto-form-block/components/Widget/HiddenWidget';
 export { default as HoneypotCaptchaWidget } from 'volto-form-block/components/Widget/HoneypotCaptchaWidget';
 export { default as NoRobotsCaptchaWidget } from 'volto-form-block/components/Widget/NoRobotsCaptchaWidget';
 export { default as RadioWidget } from 'volto-form-block/components/Widget/RadioWidget';

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -63,6 +63,10 @@ const messages = defineMessages({
     id: 'form_field_type_static_text',
     defaultMessage: 'Static text',
   },
+  field_type_hidden: {
+    id: 'form_field_type_hidden',
+    defaultMessage: 'Hidden',
+  },
 });
 
 export default (props) => {
@@ -81,6 +85,7 @@ export default (props) => {
     ['attachment', intl.formatMessage(messages.field_type_attachment)],
     ['from', intl.formatMessage(messages.field_type_from)],
     ['static_text', intl.formatMessage(messages.field_type_static_text)],
+    ['hidden', intl.formatMessage(messages.field_type_hidden)],
   ];
   var attachmentDescription =
     props?.field_type === 'attachment'

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import FieldSchema from 'volto-form-block/fieldSchema';
 import {
   SelectionSchemaExtender,
   FromSchemaExtender,
+  HiddenSchemaExtender,
 } from './components/FieldTypeSchemaExtenders';
 export {
   submitForm,
@@ -43,6 +44,7 @@ const applyConfig = (config) => {
         single_choice: SelectionSchemaExtender,
         multiple_choice: SelectionSchemaExtender,
         from: FromSchemaExtender,
+        hidden: HiddenSchemaExtender,
       },
       restricted: false,
       mostUsed: true,


### PR DESCRIPTION
This PR adds a `hidden` input type which simply displays an `<input type='hidden' />`. The value for this input is set in a text field in the form edit settings.

## Example

<img width="577" alt="" src="https://user-images.githubusercontent.com/30210785/204403563-a1dee28c-046b-4d00-beeb-fb1f6369433d.png">
<img width="302" alt="" src="https://user-images.githubusercontent.com/30210785/204403569-9a61d5a5-3d68-41fc-9e85-84874e99621f.png">


```html
<input type="hidden" id="field-hidden__1669678495963" name="hidden__1669678495963" value="Custom value">
```