### PR TITLE
Allow sending a custom acknowledgement message to the person submitting this form

### DIFF
--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -45,12 +45,17 @@ const messages = defineMessages({
   },
   send: {
     id: 'form_send_email',
-    defaultMessage: 'Send email to recipient',
+    defaultMessage: 'Send email to',
   },
 });
 
-export default () => {
+export default (formData) => {
   var intl = useIntl();
+  const emailFields = formData.subblocks.reduce((acc, field) => {
+    return ['from', 'email'].includes(field.field_type)
+      ? [...acc, [field.id, field.label]]
+      : acc;
+  }, []);
 
   return {
     title: intl.formatMessage(messages.form),
@@ -68,6 +73,9 @@ export default () => {
           'captcha',
           'store',
           'send',
+          ...(formData.send.includes('acknowledgement')
+            ? ['acknowledgementFields', 'acknowledgementMessage']
+            : []),
         ],
       },
     ],
@@ -104,8 +112,28 @@ export default () => {
         description: intl.formatMessage(messages.attachmentSendEmail),
       },
       send: {
-        type: 'boolean',
         title: intl.formatMessage(messages.send),
+        isMulti: 'true',
+        default: 'recipient',
+        choices: [
+          ['recipient', 'Recipient'],
+          ['acknowledgement', 'Acknowledgement'],
+        ],
+      },
+      acknowledgementMessage: {
+        // TODO: i18n
+        title: 'Acknowledgement message',
+        widget: 'richtext',
+      },
+      acknowledgementFields: {
+        // TODO: i18n
+        title: 'Acknowledgement field',
+        decription:
+          'Select which fields will contain an email address to send an acknowledgement to.',
+        isMulti: false,
+        noValueOption: false,
+        choices: formData.subblocks ? emailFields : [],
+        ...(emailFields.length === 1 && { default: emailFields[0][0] }),
       },
     },
     required: ['default_to', 'default_from', 'default_subject'],

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -74,7 +74,7 @@ export default (formData) => {
           'captcha',
           'store',
           'send',
-          ...(formData.send.includes('acknowledgement')
+          ...(formData.send?.includes('acknowledgement')
             ? ['acknowledgementFields', 'acknowledgementMessage']
             : []),
         ],

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -46,6 +46,10 @@ const messages = defineMessages({
     id: 'form_send_email',
     defaultMessage: 'Send email to',
   },
+  send_acknowledgement_field_description: {
+    id: 'form_send_acknowledgement_field_description',
+    defaultMessage: 'Send 'Select which fields will contain an email address to send an acknowledgement to.' to',
+  },
 });
 
 export default (formData) => {
@@ -130,8 +134,7 @@ export default (formData) => {
       acknowledgementFields: {
         // TODO: i18n
         title: 'Acknowledgement field',
-        description:
-          'Select which fields will contain an email address to send an acknowledgement to.',
+        description: intl.formatMessage(messages.send_acknowledgement_field_description),
         isMulti: false,
         noValueOption: false,
         choices: formData?.subblocks ? emailFields : [],

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -1,5 +1,4 @@
-import { defineMessages } from 'react-intl';
-import { useIntl } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
   form: {
@@ -74,7 +73,9 @@ export default (formData) => {
           'captcha',
           'store',
           'send',
-          ...(formData?.send?.includes('acknowledgement')
+          ...(formData?.send &&
+          Array.isArray(formData.send) &&
+          formData.send.includes('acknowledgement')
             ? ['acknowledgementFields', 'acknowledgementMessage']
             : []),
         ],

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -51,11 +51,12 @@ const messages = defineMessages({
 
 export default (formData) => {
   var intl = useIntl();
-  const emailFields = formData.subblocks.reduce((acc, field) => {
-    return ['from', 'email'].includes(field.field_type)
-      ? [...acc, [field.id, field.label]]
-      : acc;
-  }, []);
+  const emailFields =
+    formData.subblocks?.reduce((acc, field) => {
+      return ['from', 'email'].includes(field.field_type)
+        ? [...acc, [field.id, field.label]]
+        : acc;
+    }, []) ?? [];
 
   return {
     title: intl.formatMessage(messages.form),

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -48,7 +48,8 @@ const messages = defineMessages({
   },
   send_acknowledgement_field_description: {
     id: 'form_send_acknowledgement_field_description',
-    defaultMessage: 'Send 'Select which fields will contain an email address to send an acknowledgement to.' to',
+    defaultMessage:
+      'Select which fields will contain an email address to send an acknowledgement to.',
   },
 });
 

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -52,7 +52,7 @@ const messages = defineMessages({
 export default (formData) => {
   var intl = useIntl();
   const emailFields =
-    formData.subblocks?.reduce((acc, field) => {
+    formData?.subblocks?.reduce((acc, field) => {
       return ['from', 'email'].includes(field.field_type)
         ? [...acc, [field.id, field.label]]
         : acc;
@@ -74,7 +74,7 @@ export default (formData) => {
           'captcha',
           'store',
           'send',
-          ...(formData.send?.includes('acknowledgement')
+          ...(formData?.send?.includes('acknowledgement')
             ? ['acknowledgementFields', 'acknowledgementMessage']
             : []),
         ],
@@ -133,7 +133,7 @@ export default (formData) => {
           'Select which fields will contain an email address to send an acknowledgement to.',
         isMulti: false,
         noValueOption: false,
-        choices: formData.subblocks ? emailFields : [],
+        choices: formData?.subblocks ? emailFields : [],
         ...(emailFields.length === 1 && { default: emailFields[0][0] }),
       },
     },

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -130,7 +130,7 @@ export default (formData) => {
       acknowledgementFields: {
         // TODO: i18n
         title: 'Acknowledgement field',
-        decription:
+        description:
           'Select which fields will contain an email address to send an acknowledgement to.',
         isMulti: false,
         noValueOption: false,


### PR DESCRIPTION
This PR changes the 'send' field to be a multi-select, letting you select 'recipient' or 'acknowledgement'. When acknowledgement is selected, a dropdown for which field to send the acknowledgement appears (and if there is only one email field will be pre-filled with that field). Then a rich text field is visible below letting the editor create a custom message to send. This custom message is then sent to the user filling out the form

Required collective/collective.volto.formsupport#24

## Sample

<img width="1788" alt="Screenshot of the new settings. The 'Send' field is now a dropdown and has the values of 'recipient' and 'acknowledgement'." src="https://user-images.githubusercontent.com/30210785/207350562-7ff47962-e6b3-4bbf-a772-a049853d46f8.png">


### Email sent to recipient

```
From: noreply@plone.org
To: jeff.bledsoe@pretagov.com.au
Subject: Test
Reply-To: noreply@plone.org
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: quoted-printable
MIME-Version: 1.0
Date: Tue, 13 Dec 2022 13:56:51 +0000


  <p>A new form has been submitted from <strong>Volto form block (custom send=
 to)</strong>:</p>
  <ul>
   =20
      <li>
          <strong>Text:</strong> Test
      </li>
   =20
      <li>
          <strong>My email field:</strong> jeff.bledsoe@pretagov.co.uk
      </li>
   =20
  </ul>
````


### Email sent sent as acknowledgement

```
From: noreply@plone.org
To: jeff.bledsoe@pretagov.co.uk
Subject: Test
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: quoted-printable
MIME-Version: 1.0
Date: Tue, 13 Dec 2022 13:56:52 +0000

<p>This is an email to <a href=3D"http://jeffersonbledsoe.com/" rel=3D"noopene=
r noreferrer">the submitter</a></p><p>Thank <strong><u>you</u></strong> for s=
ubmitting this form!</p><p><em>All the best,</em></p><p><em>Jeff</em></p>
```