### PR TITLE
feat: make attachment type field list configurable in config

### DIFF
--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -150,7 +150,9 @@ const View = ({ data, id, path }) => {
             let name = getFieldName(subblock.label, subblock.id);
             if (formattedFormData[name]?.value) {
               formattedFormData[name].field_id = subblock.field_id;
-              const isAttachment = subblock.field_type === 'attachment';
+              const isAttachment = config.blocks.blocksConfig.form.attachment_fields.includes(
+                subblock.field_type,
+              );
               const isDate = subblock.field_type === 'date';
 
               if (isAttachment) {

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ const applyConfig = (config) => {
         multiple_choice: SelectionSchemaExtender,
         from: FromSchemaExtender,
       },
+      attachment_fields: ['attachment'],
       restricted: false,
       mostUsed: true,
       security: {


### PR DESCRIPTION
Right now only the field type "attachment" is sent as attachment to the back-end endpoint.

This these changes, we make the attachment field list configurable at block level, to be able to add additional field types there, for instance, those that can be added as additional fields with additional checks or whatever.