### PR TITLE
UI for including additional headers

### DIFF
--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -34,7 +34,10 @@ const messages = defineMessages({
     id: 'captcha',
     defaultMessage: 'Captcha provider',
   },
-
+  headers: {
+    id: 'Headers',
+    defaultMessage: 'Headers',
+  },
   store: {
     id: 'form_save_persistent_data',
     defaultMessage: 'Store compiled data',
@@ -49,28 +52,38 @@ const messages = defineMessages({
   },
 });
 
-export default () => {
+export default (formData) => {
   var intl = useIntl();
+
+  const fieldsets = [
+    {
+      id: 'default',
+      title: 'Default',
+      fields: [
+        'title',
+        'description',
+        'default_to',
+        'default_from',
+        'default_subject',
+        'submit_label',
+        'captcha',
+        'store',
+        'send',
+      ],
+    },
+  ];
+
+  if (formData?.send) {
+    fieldsets.push({
+      id: 'sendingOptions',
+      title: 'Sending options',
+      fields: ['httpHeaders'],
+    });
+  }
 
   return {
     title: intl.formatMessage(messages.form),
-    fieldsets: [
-      {
-        id: 'default',
-        title: 'Default',
-        fields: [
-          'title',
-          'description',
-          'default_to',
-          'default_from',
-          'default_subject',
-          'submit_label',
-          'captcha',
-          'store',
-          'send',
-        ],
-      },
-    ],
+    fieldsets: fieldsets,
     properties: {
       title: {
         title: intl.formatMessage(messages.title),
@@ -106,6 +119,23 @@ export default () => {
       send: {
         type: 'boolean',
         title: intl.formatMessage(messages.send),
+      },
+      httpHeaders: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.headers),
+        type: 'string',
+        factory: 'Choice',
+        default: '',
+        isMulti: true,
+        noValueOption: false,
+        choices: [
+          ['HTTP_X_FORWARDED_FOR','HTTP_X_FORWARDED_FOR'],
+          ['HTTP_X_FORWARDED_PORT','HTTP_X_FORWARDED_PORT'],
+          ['REMOTE_ADDR','REMOTE_ADDR'],
+          ['PATH_INFO','PATH_INFO'],
+          ['HTTP_USER_AGENT','HTTP_USER_AGENT'],
+          ['HTTP_REFERER','HTTP_REFERER'],
+        ],
       },
     },
     required: ['default_to', 'default_from', 'default_subject'],

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -38,6 +38,10 @@ const messages = defineMessages({
     id: 'Headers',
     defaultMessage: 'Headers',
   },
+  headersDescription: {
+    id: 'Headers Description',
+    defaultMessage: "These headers aren't included in the sent email by default. Use this dropdown to include them in the sent email",
+  },
   store: {
     id: 'form_save_persistent_data',
     defaultMessage: 'Store compiled data',
@@ -123,6 +127,7 @@ export default (formData) => {
       httpHeaders: {
         type: 'boolean',
         title: intl.formatMessage(messages.headers),
+        description: intl.formatMessage(messages.headersDescription),
         type: 'string',
         factory: 'Choice',
         default: '',


### PR DESCRIPTION
This PR adds the UI to replicate the functionality in collective.easyform to include additional headers in the sent email.

Requires collective/collective.volto.formsupport#27 (merged, pending release)