### PR TITLE
Add option to change email format

### DIFF
--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -47,30 +47,44 @@ const messages = defineMessages({
     id: 'form_send_email',
     defaultMessage: 'Send email to recipient',
   },
+  email_format: {
+    id: 'form_email_format',
+    defaultMessage: 'Email format',
+  },
 });
 
-export default () => {
+export default (formData) => {
   var intl = useIntl();
+
+  const fieldsets = [
+    {
+      id: 'default',
+      title: 'Default',
+      fields: [
+        'title',
+        'description',
+        'default_to',
+        'default_from',
+        'default_subject',
+        'submit_label',
+        'captcha',
+        'store',
+        'send',
+      ],
+    },
+  ];
+
+  if (formData?.send) {
+    fieldsets.push({
+      id: 'sendingOptions',
+      title: 'Sending options',
+      fields: ['email_format'],
+    });
+  }
 
   return {
     title: intl.formatMessage(messages.form),
-    fieldsets: [
-      {
-        id: 'default',
-        title: 'Default',
-        fields: [
-          'title',
-          'description',
-          'default_to',
-          'default_from',
-          'default_subject',
-          'submit_label',
-          'captcha',
-          'store',
-          'send',
-        ],
-      },
-    ],
+    fieldsets: fieldsets,
     properties: {
       title: {
         title: intl.formatMessage(messages.title),
@@ -106,6 +120,15 @@ export default () => {
       send: {
         type: 'boolean',
         title: intl.formatMessage(messages.send),
+      },
+      email_format: {
+        title: intl.formatMessage(messages.email_format),
+        type: 'string',
+        choices: [
+          ['list', 'List'],
+          ['table', 'Table'],
+        ],
+        noValueOption: false,
       },
     },
     required: ['default_to', 'default_from', 'default_subject'],


### PR DESCRIPTION
Requires collective/collective.volto.formsupport#31

[collective.volto.formsupport](https://github.com/collective/collective.volto.formsupport) currently only supports viewing the email as a `<ul>`. We've had a request to be able to display the sent information as a table (like with easyform), as a client uses the table markup in further processing. This PR adds a setting to the frontend to allow changing how the sent email will be displayed.

## Screenshots

<img width="330" alt="Screenshot 2023-04-25 at 4 42 52 pm" src="https://user-images.githubusercontent.com/30210785/234331818-56a13f00-9646-4313-81a4-6045032f19eb.png">

See the backend PR to view the markup sent
 fixes pretagov/nsw-demo#266