### PR TITLE
Use string for field_type

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "pre-commit": "lint-staged"
     }
   },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all"
+  },
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^0.3.6",
     "file-saver": "^2.0.5",

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -1,92 +1,92 @@
-import config from "@plone/volto/registry";
-import { defineMessages } from "react-intl";
-import { useIntl } from "react-intl";
+import config from '@plone/volto/registry';
+import { defineMessages } from 'react-intl';
+import { useIntl } from 'react-intl';
 
 const messages = defineMessages({
   field_label: {
-    id: "form_field_label",
-    defaultMessage: "Label",
+    id: 'form_field_label',
+    defaultMessage: 'Label',
   },
   field_description: {
-    id: "form_field_description",
-    defaultMessage: "Description",
+    id: 'form_field_description',
+    defaultMessage: 'Description',
   },
   field_required: {
-    id: "form_field_required",
-    defaultMessage: "Required",
+    id: 'form_field_required',
+    defaultMessage: 'Required',
   },
   field_type: {
-    id: "form_field_type",
-    defaultMessage: "Field type",
+    id: 'form_field_type',
+    defaultMessage: 'Field type',
   },
   field_type_text: {
-    id: "form_field_type_text",
-    defaultMessage: "Text",
+    id: 'form_field_type_text',
+    defaultMessage: 'Text',
   },
   field_type_textarea: {
-    id: "form_field_type_textarea",
-    defaultMessage: "Textarea",
+    id: 'form_field_type_textarea',
+    defaultMessage: 'Textarea',
   },
   field_type_select: {
-    id: "form_field_type_select",
-    defaultMessage: "List",
+    id: 'form_field_type_select',
+    defaultMessage: 'List',
   },
   field_type_single_choice: {
-    id: "form_field_type_single_choice",
-    defaultMessage: "Single choice",
+    id: 'form_field_type_single_choice',
+    defaultMessage: 'Single choice',
   },
   field_type_multiple_choice: {
-    id: "form_field_type_multiple_choice",
-    defaultMessage: "Multiple choice",
+    id: 'form_field_type_multiple_choice',
+    defaultMessage: 'Multiple choice',
   },
   field_type_checkbox: {
-    id: "form_field_type_checkbox",
-    defaultMessage: "Checkbox",
+    id: 'form_field_type_checkbox',
+    defaultMessage: 'Checkbox',
   },
   field_type_date: {
-    id: "form_field_type_date",
-    defaultMessage: "Date",
+    id: 'form_field_type_date',
+    defaultMessage: 'Date',
   },
   field_type_attachment: {
-    id: "form_field_type_attachment",
-    defaultMessage: "Attachment",
+    id: 'form_field_type_attachment',
+    defaultMessage: 'Attachment',
   },
   field_type_attachment_info_text: {
-    id: "form_field_type_attachment_info_text",
-    defaultMessage: "Any attachments can be emailed, but will not be saved.",
+    id: 'form_field_type_attachment_info_text',
+    defaultMessage: 'Any attachments can be emailed, but will not be saved.',
   },
   field_type_from: {
-    id: "form_field_type_from",
-    defaultMessage: "E-mail",
+    id: 'form_field_type_from',
+    defaultMessage: 'E-mail',
   },
   field_type_static_text: {
-    id: "form_field_type_static_text",
-    defaultMessage: "Static text",
+    id: 'form_field_type_static_text',
+    defaultMessage: 'Static text',
   },
 });
 
 export default (props) => {
   var intl = useIntl();
   const baseFieldTypeChoices = [
-    ["text", intl.formatMessage(messages.field_type_text)],
-    ["textarea", intl.formatMessage(messages.field_type_textarea)],
-    ["select", intl.formatMessage(messages.field_type_select)],
-    ["single_choice", intl.formatMessage(messages.field_type_single_choice)],
+    ['text', intl.formatMessage(messages.field_type_text)],
+    ['textarea', intl.formatMessage(messages.field_type_textarea)],
+    ['select', intl.formatMessage(messages.field_type_select)],
+    ['single_choice', intl.formatMessage(messages.field_type_single_choice)],
     [
-      "multiple_choice",
+      'multiple_choice',
       intl.formatMessage(messages.field_type_multiple_choice),
     ],
-    ["checkbox", intl.formatMessage(messages.field_type_checkbox)],
-    ["date", intl.formatMessage(messages.field_type_date)],
-    ["attachment", intl.formatMessage(messages.field_type_attachment)],
-    ["from", intl.formatMessage(messages.field_type_from)],
-    ["static_text", intl.formatMessage(messages.field_type_static_text)],
+    ['checkbox', intl.formatMessage(messages.field_type_checkbox)],
+    ['date', intl.formatMessage(messages.field_type_date)],
+    ['attachment', intl.formatMessage(messages.field_type_attachment)],
+    ['from', intl.formatMessage(messages.field_type_from)],
+    ['static_text', intl.formatMessage(messages.field_type_static_text)],
   ];
   var attachmentDescription =
-    props?.field_type === "attachment"
+    props?.field_type === 'attachment'
       ? {
           description: intl.formatMessage(
-            messages.field_type_attachment_info_text
+            messages.field_type_attachment_info_text,
           ),
         }
       : {};
@@ -97,17 +97,17 @@ export default (props) => {
     ? schemaExtender(intl)
     : { properties: [], fields: [], required: [] };
   return {
-    title: props?.label || "",
+    title: props?.label || '',
     fieldsets: [
       {
-        id: "default",
-        title: "Default",
+        id: 'default',
+        title: 'Default',
         fields: [
-          "label",
-          "description",
-          "field_type",
+          'label',
+          'description',
+          'field_type',
           ...schemaExtenderValues.fields,
-          "required",
+          'required',
         ],
       },
     ],
@@ -122,26 +122,26 @@ export default (props) => {
       },
       field_type: {
         title: intl.formatMessage(messages.field_type),
-        type: "string",
+        type: 'string',
         choices: [
           ...baseFieldTypeChoices,
           ...(config.blocks.blocksConfig.form.additionalFields?.map(
-            (fieldType) => [fieldType.id, fieldType.label]
+            (fieldType) => [fieldType.id, fieldType.label],
           ) ?? []),
         ],
         ...attachmentDescription,
       },
       required: {
         title: intl.formatMessage(messages.field_required),
-        type: "boolean",
+        type: 'boolean',
         default: false,
       },
       ...schemaExtenderValues.properties,
     },
     required: [
-      "label",
-      "field_type",
-      "input_values",
+      'label',
+      'field_type',
+      'input_values',
       ...schemaExtenderValues.required,
     ],
   };

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -1,92 +1,92 @@
-import config from '@plone/volto/registry';
-import { defineMessages } from 'react-intl';
-import { useIntl } from 'react-intl';
+import config from "@plone/volto/registry";
+import { defineMessages } from "react-intl";
+import { useIntl } from "react-intl";
 
 const messages = defineMessages({
   field_label: {
-    id: 'form_field_label',
-    defaultMessage: 'Label',
+    id: "form_field_label",
+    defaultMessage: "Label",
   },
   field_description: {
-    id: 'form_field_description',
-    defaultMessage: 'Description',
+    id: "form_field_description",
+    defaultMessage: "Description",
   },
   field_required: {
-    id: 'form_field_required',
-    defaultMessage: 'Required',
+    id: "form_field_required",
+    defaultMessage: "Required",
   },
   field_type: {
-    id: 'form_field_type',
-    defaultMessage: 'Field type',
+    id: "form_field_type",
+    defaultMessage: "Field type",
   },
   field_type_text: {
-    id: 'form_field_type_text',
-    defaultMessage: 'Text',
+    id: "form_field_type_text",
+    defaultMessage: "Text",
   },
   field_type_textarea: {
-    id: 'form_field_type_textarea',
-    defaultMessage: 'Textarea',
+    id: "form_field_type_textarea",
+    defaultMessage: "Textarea",
   },
   field_type_select: {
-    id: 'form_field_type_select',
-    defaultMessage: 'List',
+    id: "form_field_type_select",
+    defaultMessage: "List",
   },
   field_type_single_choice: {
-    id: 'form_field_type_single_choice',
-    defaultMessage: 'Single choice',
+    id: "form_field_type_single_choice",
+    defaultMessage: "Single choice",
   },
   field_type_multiple_choice: {
-    id: 'form_field_type_multiple_choice',
-    defaultMessage: 'Multiple choice',
+    id: "form_field_type_multiple_choice",
+    defaultMessage: "Multiple choice",
   },
   field_type_checkbox: {
-    id: 'form_field_type_checkbox',
-    defaultMessage: 'Checkbox',
+    id: "form_field_type_checkbox",
+    defaultMessage: "Checkbox",
   },
   field_type_date: {
-    id: 'form_field_type_date',
-    defaultMessage: 'Date',
+    id: "form_field_type_date",
+    defaultMessage: "Date",
   },
   field_type_attachment: {
-    id: 'form_field_type_attachment',
-    defaultMessage: 'Attachment',
+    id: "form_field_type_attachment",
+    defaultMessage: "Attachment",
   },
   field_type_attachment_info_text: {
-    id: 'form_field_type_attachment_info_text',
-    defaultMessage: 'Any attachments can be emailed, but will not be saved.',
+    id: "form_field_type_attachment_info_text",
+    defaultMessage: "Any attachments can be emailed, but will not be saved.",
   },
   field_type_from: {
-    id: 'form_field_type_from',
-    defaultMessage: 'E-mail',
+    id: "form_field_type_from",
+    defaultMessage: "E-mail",
   },
   field_type_static_text: {
-    id: 'form_field_type_static_text',
-    defaultMessage: 'Static text',
+    id: "form_field_type_static_text",
+    defaultMessage: "Static text",
   },
 });
 
 export default (props) => {
   var intl = useIntl();
   const baseFieldTypeChoices = [
-    ['text', intl.formatMessage(messages.field_type_text)],
-    ['textarea', intl.formatMessage(messages.field_type_textarea)],
-    ['select', intl.formatMessage(messages.field_type_select)],
-    ['single_choice', intl.formatMessage(messages.field_type_single_choice)],
+    ["text", intl.formatMessage(messages.field_type_text)],
+    ["textarea", intl.formatMessage(messages.field_type_textarea)],
+    ["select", intl.formatMessage(messages.field_type_select)],
+    ["single_choice", intl.formatMessage(messages.field_type_single_choice)],
     [
-      'multiple_choice',
+      "multiple_choice",
       intl.formatMessage(messages.field_type_multiple_choice),
     ],
-    ['checkbox', intl.formatMessage(messages.field_type_checkbox)],
-    ['date', intl.formatMessage(messages.field_type_date)],
-    ['attachment', intl.formatMessage(messages.field_type_attachment)],
-    ['from', intl.formatMessage(messages.field_type_from)],
-    ['static_text', intl.formatMessage(messages.field_type_static_text)],
+    ["checkbox", intl.formatMessage(messages.field_type_checkbox)],
+    ["date", intl.formatMessage(messages.field_type_date)],
+    ["attachment", intl.formatMessage(messages.field_type_attachment)],
+    ["from", intl.formatMessage(messages.field_type_from)],
+    ["static_text", intl.formatMessage(messages.field_type_static_text)],
   ];
   var attachmentDescription =
-    props?.field_type === 'attachment'
+    props?.field_type === "attachment"
       ? {
           description: intl.formatMessage(
-            messages.field_type_attachment_info_text,
+            messages.field_type_attachment_info_text
           ),
         }
       : {};
@@ -97,17 +97,17 @@ export default (props) => {
     ? schemaExtender(intl)
     : { properties: [], fields: [], required: [] };
   return {
-    title: props?.label || '',
+    title: props?.label || "",
     fieldsets: [
       {
-        id: 'default',
-        title: 'Default',
+        id: "default",
+        title: "Default",
         fields: [
-          'label',
-          'description',
-          'field_type',
+          "label",
+          "description",
+          "field_type",
           ...schemaExtenderValues.fields,
-          'required',
+          "required",
         ],
       },
     ],
@@ -122,26 +122,26 @@ export default (props) => {
       },
       field_type: {
         title: intl.formatMessage(messages.field_type),
-        type: 'array',
+        type: "string",
         choices: [
           ...baseFieldTypeChoices,
           ...(config.blocks.blocksConfig.form.additionalFields?.map(
-            (fieldType) => [fieldType.id, fieldType.label],
+            (fieldType) => [fieldType.id, fieldType.label]
           ) ?? []),
         ],
         ...attachmentDescription,
       },
       required: {
         title: intl.formatMessage(messages.field_required),
-        type: 'boolean',
+        type: "boolean",
         default: false,
       },
       ...schemaExtenderValues.properties,
     },
     required: [
-      'label',
-      'field_type',
-      'input_values',
+      "label",
+      "field_type",
+      "input_values",
       ...schemaExtenderValues.required,
     ],
   };


### PR DESCRIPTION
As highlighted in #62, the `field_type` is currently an array. This logically doesn't make sense as a field can't be more than one type at a time and currently break the form UI when you change the field type from type to another

Closes  #62 