### PR TITLE
swap store / send description

### DIFF
--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -101,11 +101,11 @@ export default () => {
       store: {
         type: 'boolean',
         title: intl.formatMessage(messages.store),
-        description: intl.formatMessage(messages.attachmentSendEmail),
       },
       send: {
         type: 'boolean',
         title: intl.formatMessage(messages.send),
+        description: intl.formatMessage(messages.attachmentSendEmail),
       },
     },
     required: ['default_to', 'default_from', 'default_subject'],


### PR DESCRIPTION
`messages.attachmentSendEmail` should be the description of the `send` field (instead of `store`)