### PR TITLE
Add option for email fields to override default sender

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr "Wenn ausgewählt, wird auch eine Kopie der E-Mail an diese Adresse gesendet."
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr "Als Absender setzen"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Als Antwortadresse nutzen"
@@ -477,3 +482,8 @@ msgstr "Ergebnis"
 # defaultMessage: Title
 msgid "title"
 msgstr "Titel"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr "Standard Absender wird dann mit dieser Adresse überschrieben."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Use as 'reply to'"
@@ -477,3 +482,8 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr "Title"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -453,6 +453,11 @@ msgid "form_useAsBCC_description"
 msgstr "Si está seleccionado, una copia del mensaje se enviará a esta dirección"
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'Responder a'"
@@ -486,3 +491,8 @@ msgstr "Resultado"
 # defaultMessage: Title
 msgid "title"
 msgstr "Título"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr ""

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -446,6 +446,11 @@ msgid "form_useAsBCC_description"
 msgstr "Aukeratzen bada, emailaren kopia bat bidaliko da helbide honetara."
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Nori erantzun gisa erabili"
@@ -479,3 +484,8 @@ msgstr "emaitza"
 # defaultMessage: Title
 msgid "title"
 msgstr "Izenburua"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -476,4 +481,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr "Se selezionato, una copia dell'email verrà inviata anche a questo indirizzo."
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Usa come 'reply to'"
@@ -477,3 +482,8 @@ msgstr "risultato"
 # defaultMessage: Title
 msgid "title"
 msgstr "Titolo"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr ""

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -476,4 +481,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -476,4 +481,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -476,4 +481,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -450,6 +450,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'responder para'"
@@ -483,3 +488,8 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr "título"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
+msgstr ""

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -476,4 +481,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-05-29T11:05:12.094Z\n"
+"POT-Creation-Date: 2023-09-12T08:29:55.978Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -446,6 +446,11 @@ msgid "form_useAsBCC_description"
 msgstr ""
 
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'from'
+msgid "form_useAsFrom"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
 # defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr ""
@@ -478,4 +483,9 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will override the default sender.
+msgid "useAsFrom_description"
 msgstr ""

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,7 +13,7 @@ export const SUBMIT_FORM_ACTION = 'SUBMIT_FORM_ACTION';
  * @param {Object} data
  * @returns {Object} attachments
  */
-export function submitForm(path = '', block_id, data, attachments, captcha) {
+export function submitForm(path = '', block_id, data, attachments, captcha, from) {
   return {
     type: SUBMIT_FORM_ACTION,
     request: {
@@ -24,6 +24,7 @@ export function submitForm(path = '', block_id, data, attachments, captcha) {
         data,
         attachments,
         captcha,
+        from,
       },
     },
   };

--- a/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
+++ b/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
@@ -4,6 +4,14 @@ const messages = defineMessages({
     id: 'form_field_input_values',
     defaultMessage: 'Possible values',
   },
+  useAsFrom: {
+    id: 'form_useAsFrom',
+    defaultMessage: "Use as 'from'",
+  },
+  useAsFrom_description: {
+    id: 'useAsFrom_description',
+    defaultMessage: 'If selected, this will override the default sender.',
+  },
   useAsReplyTo: {
     id: 'form_useAsReplyTo',
     defaultMessage: "Use as 'reply to'",
@@ -26,8 +34,14 @@ const messages = defineMessages({
 
 export const FromSchemaExtender = (intl) => {
   return {
-    fields: ['use_as_reply_to', 'use_as_bcc'],
+    fields: ['use_as_from', 'use_as_reply_to', 'use_as_bcc'],
     properties: {
+      use_as_from: {
+        title: intl.formatMessage(messages.useAsFrom),
+        description: intl.formatMessage(messages.useAsFrom_description),
+        type: 'boolean',
+        default: false,
+      },
       use_as_reply_to: {
         title: intl.formatMessage(messages.useAsReplyTo),
         description: intl.formatMessage(messages.useAsReplyTo_description),

--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -188,6 +188,20 @@ const View = ({ data, id, path }) => {
               }
             }
           });
+
+          // if there is an email field which should be used as sender,
+          // we want to set from value regarding this field
+          let from = null;
+          const fromField = data.subblocks.find(
+            (b) => ['email', 'from'].includes(b.field_type) && b.use_as_from,
+          );
+          if (fromField) {
+            const fromFieldId = `email_${fromField.field_id}`;
+            if (formData.hasOwnProperty(fromFieldId)) {
+              from = formData[fromFieldId].value;
+            }
+          }
+
           dispatch(
             submitForm(
               path,
@@ -197,6 +211,7 @@ const View = ({ data, id, path }) => {
               })),
               attachments,
               captcha,
+              from,
             ),
           );
           setFormState({ type: FORM_STATES.loading });


### PR DESCRIPTION
Adds a checkbox to email fields `Use as 'from'`. If set, the value of the email field will be set as email sender (and therefore override the default sender).