### PR TITLE
Add option for email fields to set logged in users email as default

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr "Ergebnis"
 # defaultMessage: Title
 msgid "title"
 msgstr "Titel"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr "Mit E-Mail von eingeloggtem Benutzer vorausfüllen"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr "Wenn Benutzer eingeloggt ist, wird dessen E-Mail-Adresse automatisch in das Feld eingetragen."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr "Title"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -486,3 +486,13 @@ msgstr "Resultado"
 # defaultMessage: Title
 msgid "title"
 msgstr "Título"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -479,3 +479,13 @@ msgstr "emaitza"
 # defaultMessage: Title
 msgid "title"
 msgstr "Izenburua"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr "risultato"
 # defaultMessage: Title
 msgid "title"
 msgstr "Titolo"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -483,3 +483,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr "título"
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -477,3 +477,13 @@ msgstr ""
 # defaultMessage: Title
 msgid "title"
 msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
+msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-05-29T11:05:12.094Z\n"
+"POT-Creation-Date: 2023-09-12T11:11:32.690Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -478,4 +478,14 @@ msgstr ""
 #: formSchema
 # defaultMessage: Title
 msgid "title"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use email of logged in user as default
+msgid "userEmailAsDefault"
+msgstr ""
+
+#: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected and user is logged in, his/her email address will be set as default value.
+msgid "userEmailAsDefault_description"
 msgstr ""

--- a/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
+++ b/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
@@ -29,7 +29,7 @@ const messages = defineMessages({
   userEmailAsDefault_description: {
     id: 'userEmailAsDefault_description',
     defaultMessage:
-      'If selected and user is logged in, his/her email address will be set as default value.',
+      'If selected and user is logged in, their email address will be set as default value.',
   },
 });
 

--- a/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
+++ b/src/components/FieldTypeSchemaExtenders/FromSchemaExtender.js
@@ -22,11 +22,20 @@ const messages = defineMessages({
     defaultMessage:
       'If selected, a copy of email will alse be sent to this address.',
   },
+  userEmailAsDefault: {
+    id: 'userEmailAsDefault',
+    defaultMessage: 'Use email of logged in user as default',
+  },
+  userEmailAsDefault_description: {
+    id: 'userEmailAsDefault_description',
+    defaultMessage:
+      'If selected and user is logged in, his/her email address will be set as default value.',
+  },
 });
 
 export const FromSchemaExtender = (intl) => {
   return {
-    fields: ['use_as_reply_to', 'use_as_bcc'],
+    fields: ['use_as_reply_to', 'use_as_bcc', 'user_email_as_default'],
     properties: {
       use_as_reply_to: {
         title: intl.formatMessage(messages.useAsReplyTo),
@@ -37,6 +46,14 @@ export const FromSchemaExtender = (intl) => {
       use_as_bcc: {
         title: intl.formatMessage(messages.useAsBCC),
         description: intl.formatMessage(messages.useAsBCC_description),
+        type: 'boolean',
+        default: false,
+      },
+      user_email_as_default: {
+        title: intl.formatMessage(messages.userEmailAsDefault),
+        description: intl.formatMessage(
+          messages.userEmailAsDefault_description,
+        ),
         type: 'boolean',
         default: false,
       },

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -80,12 +80,13 @@ const FormView = ({
   const userId = useSelector((state) =>
     state.userSession.token ? jwtDecode(state.userSession.token).sub : '',
   );
+  const isUserLoaded = useSelector((state) => state.users?.get?.loaded);
   const curUserEmail = useSelector(
     (state) => state.users?.user?.email || false,
   );
   const dispatch = useDispatch();
   useEffect(() => {
-    if (userId?.length > 0 && curUserEmail === false) dispatch(getUser(userId));
+    if (userId?.length > 0 && !isUserLoaded) dispatch(getUser(userId));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId]);
 

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -72,7 +72,7 @@ const FormView = ({
     data.subblocks.forEach((subblock) => {
       if (
         ['email', 'from'].includes(subblock.field_type) &&
-        subblock.user_email_as_default === true
+        subblock.user_email_as_default
       ) {
         const name = getFieldName(subblock.label, subblock.id);
         if (!formData.hasOwnProperty(name))


### PR DESCRIPTION
Adds checkbox to email fields `Use email of logged in user as default`.

If selected and user is logged in, the field will get pre-filled with the users email address.