### PR TITLE
feat: added form reset button and an user customizable sending message

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr "Beschreibung"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr "Formular erfolgreich eingereicht"
 msgid "form_attachment_send_email_info_text"
 msgstr "Angeheftete Datei wird ohne zu speichern per E-mail versendet."
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -265,6 +275,12 @@ msgstr "Daten löschen"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Gespeicherte Elemente wirklich löschen?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Default sender
@@ -417,6 +433,21 @@ msgstr "Wählen Sie einen Wert"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "E-Mail an Empfänger senden"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -278,7 +278,7 @@ msgstr "Are you sure you want to delete all saved items?"
 
 #: components/Edit
 #: components/FormView
-# defaultMessage: Cancel
+# defaultMessage: Annulla
 msgid "form_default_cancel_label"
 msgstr "Cancel"
 
@@ -440,9 +440,9 @@ msgid "form_send_message"
 msgstr "Message of sending confirmed"
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
-msgstr "You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting."
+msgstr "You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting."
 
 #: formSchema
 # defaultMessage: Show cancel button

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr "Description"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr "Field ID"
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr "Form successfully submitted"
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr "Cancel button label"
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -265,6 +275,12 @@ msgstr "Clear data"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Are you sure you want to delete all saved items?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Cancel
+msgid "form_default_cancel_label"
+msgstr "Cancel"
 
 #: formSchema
 # defaultMessage: Default sender
@@ -417,6 +433,21 @@ msgstr "Select a value"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Send email to recipient"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr "Message of sending confirmed"
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr "You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting."
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr "Show cancel button"
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -449,7 +449,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -250,6 +250,11 @@ msgstr "Proveedor de captchas"
 msgid "description"
 msgstr "Descripción"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -265,6 +270,11 @@ msgstr "El formulario se ha enviado correctamente"
 msgid "form_attachment_send_email_info_text"
 msgstr "El archivo adjunto se enviará por correo electrónico pero no se almacenará"
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -274,6 +284,12 @@ msgstr "Borrar datos"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "¿Está seguro de que quiere borrar todos los datos guardados?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Default sender
@@ -426,6 +442,21 @@ msgstr "Seleccione un valor"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar correo electrónico al receptor"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -243,6 +243,11 @@ msgstr ""
 msgid "description"
 msgstr "Deskribapena"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -258,6 +263,11 @@ msgstr "Formularioa ondo bidali da"
 msgid "form_attachment_send_email_info_text"
 msgstr "Erantsitako fitxategia email bidez bidaliko da, baina ez da gordeko"
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -267,6 +277,12 @@ msgstr "Garbitu datuak"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Ziur zaude mezu guztiak ezabatu nahi dituzula?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Default sender
@@ -419,6 +435,21 @@ msgstr "Aukeratu balio bat"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Bidali posta elektronikoa jasotzaileari"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -442,7 +442,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr "Formulaire soumis avec succès"
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -265,6 +275,12 @@ msgstr "Effacer les données"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Voulez-vous vraiment supprimer tous les éléments enregistrés?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Default sender
@@ -417,6 +433,21 @@ msgstr "Sélectionnez une valeur"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Envoyer un e-mail au destinataire"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr "Descrizione"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr "Identificativo"
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -249,12 +254,17 @@ msgstr "Form"
 #: components/View
 # defaultMessage: Form successfully submitted
 msgid "formSubmitted"
-msgstr "Form invato correttamente"
+msgstr "Form inviato correttamente"
 
 #: formSchema
 # defaultMessage: Attached file will be sent via email, but not stored
 msgid "form_attachment_send_email_info_text"
 msgstr "Il file allegato sarà inviato via email, ma non verrà salvato"
+
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr "Testo sul bottone annulla"
 
 #: components/Sidebar
 # defaultMessage: Clear data
@@ -265,6 +275,12 @@ msgstr "Pulisci dati"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Confermi di voler eliminare tutti i dati salvati?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr "Annulla"
 
 #: formSchema
 # defaultMessage: Default sender
@@ -417,6 +433,21 @@ msgstr "Seleziona un valore"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Invia email al destinatario"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr "Messaggio di conferma invio"
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr "Si può aggiungere il valore di un campo compilato nella form inserendo il suo identificativo tra parentesi graffe preceduto da $, esempio: ${identificativo_xxx}; inoltre si possono aggiungere elementi html come link, <a..></a>, nuova linea <br />, formattazioni in bold <b> e italic <i>."
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr "Mostra il bottone annulla"
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -440,9 +440,9 @@ msgid "form_send_message"
 msgstr "Messaggio di conferma invio"
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
-msgstr "Si può aggiungere il valore di un campo compilato nella form inserendo il suo identificativo tra parentesi graffe preceduto da $, esempio: ${identificativo_xxx}; inoltre si possono aggiungere elementi html come link, <a..></a>, nuova linea <br />, formattazioni in bold <b> e italic <i>."
+msgstr "Si può aggiungere il valore di un campo compilato nella form inserendo il suo identificativo tra parentesi graffe preceduto da $, esempio: ${identificativo}; inoltre si possono aggiungere elementi html come link, <a..></a>, nuova linea <br />, formattazioni in bold <b> e italic <i>."
 
 #: formSchema
 # defaultMessage: Show cancel button

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr ""
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -264,6 +274,12 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
+msgstr ""
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
 msgstr ""
 
 #: formSchema
@@ -416,6 +432,21 @@ msgstr ""
 #: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
 msgstr ""
 
 #: formSchema

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr ""
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -264,6 +274,12 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
+msgstr ""
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
 msgstr ""
 
 #: formSchema
@@ -416,6 +432,21 @@ msgstr ""
 #: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
 msgstr ""
 
 #: formSchema

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr ""
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -264,6 +274,12 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
+msgstr ""
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
 msgstr ""
 
 #: formSchema
@@ -416,6 +432,21 @@ msgstr ""
 #: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
 msgstr ""
 
 #: formSchema

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -247,6 +247,11 @@ msgstr ""
 msgid "description"
 msgstr "descrição"
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -262,6 +267,11 @@ msgstr "Formulário enviado com sucesso"
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -271,6 +281,12 @@ msgstr "Limpar dados"
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Você tem certeza que deseja apagar todos as respostas salvas?"
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Default sender
@@ -423,6 +439,21 @@ msgstr "Selecione um valor"
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar e-mail para o destinatário"
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Submit button label

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -446,7 +446,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -440,7 +440,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -256,6 +261,11 @@ msgstr ""
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -264,6 +274,12 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
+msgstr ""
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
 msgstr ""
 
 #: formSchema
@@ -416,6 +432,21 @@ msgstr ""
 #: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
 msgstr ""
 
 #: formSchema

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-05-29T11:05:12.094Z\n"
+"POT-Creation-Date: 2023-12-05T11:09:07.780Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -243,6 +243,11 @@ msgstr ""
 msgid "description"
 msgstr ""
 
+#: components/Sidebar
+# defaultMessage: Field ID
+msgid "fieldId"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"
@@ -258,6 +263,11 @@ msgstr ""
 msgid "form_attachment_send_email_info_text"
 msgstr ""
 
+#: formSchema
+# defaultMessage: Cancel button label
+msgid "form_cancel_label"
+msgstr ""
+
 #: components/Sidebar
 # defaultMessage: Clear data
 msgid "form_clear_data"
@@ -266,6 +276,12 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
+msgstr ""
+
+#: components/Edit
+#: components/FormView
+# defaultMessage: Annulla
+msgid "form_default_cancel_label"
 msgstr ""
 
 #: formSchema
@@ -418,6 +434,21 @@ msgstr ""
 #: formSchema
 # defaultMessage: Send email to recipient
 msgid "form_send_email"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Message of sending confirmed
+msgid "form_send_message"
+msgstr ""
+
+#: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+msgid "form_send_message_helptext"
+msgstr ""
+
+#: formSchema
+# defaultMessage: Show cancel button
+msgid "form_show_cancel"
 msgstr ""
 
 #: formSchema

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-12-05T11:09:07.780Z\n"
+"POT-Creation-Date: 2023-12-06T09:16:14.589Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -442,7 +442,7 @@ msgid "form_send_message"
 msgstr ""
 
 #: formSchema
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr ""
 

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -21,6 +21,10 @@ const messages = defineMessages({
     id: 'form_default_submit_label',
     defaultMessage: 'Invia',
   },
+  default_cancel_label: {
+    id: 'form_default_cancel_label',
+    defaultMessage: 'Annulla',
+  },
   warning: {
     id: 'form_edit_warning',
     defaultMessage: 'Attenzione!',
@@ -93,6 +97,14 @@ class Edit extends SubblocksEdit {
             <Grid columns={1} padded="vertically">
               <Grid.Row>
                 <Grid.Column textAlign="center">
+                  {this.props.data?.show_cancel && (
+                    <Button secondary>
+                      {this.props.data.cancel_label ||
+                        this.props.intl.formatMessage(
+                          messages.default_cancel_label,
+                        )}
+                    </Button>
+                  )}
                   <Button primary>
                     {this.props.data.submit_label ||
                       this.props.intl.formatMessage(

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -20,6 +20,10 @@ const messages = defineMessages({
     id: 'form_default_submit_label',
     defaultMessage: 'Submit',
   },
+  default_cancel_label: {
+    id: 'form_default_cancel_label',
+    defaultMessage: 'Cancel',
+  },
   error: {
     id: 'Error',
     defaultMessage: 'Error',
@@ -57,6 +61,23 @@ const FormView = ({
     return formErrors?.indexOf(field) < 0;
   };
 
+  /* Function that replaces variables from the user customized message  */
+  const replaceMessage = (text) => {
+    let i = 0;
+    while (i < data.subblocks.length) {
+      let idField = getFieldName(
+        data.subblocks[i].label,
+        data.subblocks[i].field_id,
+      );
+      text = text.replaceAll(
+        '${' + idField + '}',
+        formData[idField]?.value || '',
+      );
+      i++;
+    }
+    return text;
+  };
+
   return (
     <div className="block form">
       <div className="public-ui">
@@ -77,10 +98,23 @@ const FormView = ({
             </Message>
           ) : formState.result ? (
             <Message positive role="alert">
-              <Message.Header as="h4">
-                {intl.formatMessage(messages.success)}
-              </Message.Header>
-              <p>{formState.result}</p>
+              {/* Custom message */}
+              {data.send_message ? (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: replaceMessage(data.send_message),
+                  }}
+                />
+              ) : (
+                <>
+                  {/* Default message */}
+                  <Message.Header as="h4">
+                    {intl.formatMessage(messages.success)}
+                  </Message.Header>
+                  <p>{formState.result}</p>
+                </>
+              )}
+              {/* Back button */}
               <Button secondary type="clear" onClick={resetFormState}>
                 {intl.formatMessage(messages.reset)}
               </Button>
@@ -171,6 +205,12 @@ const FormView = ({
                 )}
                 <Grid.Row centered className="row-padded-top">
                   <Grid.Column textAlign="center">
+                    {data?.show_cancel && (
+                      <Button secondary type="clear" onClick={resetFormState}>
+                        {data.cancel_label ||
+                          intl.formatMessage(messages.default_cancel_label)}
+                      </Button>
+                    )}
                     <Button primary type="submit" disabled={formState.loading}>
                       {data.submit_label ||
                         intl.formatMessage(messages.default_submit_label)}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -201,27 +201,12 @@ const Sidebar = ({
                       subblock.field_type === 'from' ||
                       subblock.field_type === 'textarea' ||
                       subblock.field_type === 'date') && (
-                      <>
-                        <Form.Field inline>
-                          <Grid>
-                            <Grid.Row columns={2} style={{ margin: '1rem 0' }}>
-                              <Grid.Column width="4">
-                                {intl.formatMessage(messages.fieldId)}
-                              </Grid.Column>
-
-                              <Grid.Column width="8" style={{ opacity: '0.6' }}>
-                                <p>
-                                  {getFieldName(
-                                    subblock.label,
-                                    subblock.field_id,
-                                  )}
-                                </p>
-                                <Divider fitted />
-                              </Grid.Column>
-                            </Grid.Row>
-                          </Grid>
-                        </Form.Field>
-                      </>
+                      <Segment tertiary>
+                        {intl.formatMessage(messages.fieldId)}:{' '}
+                        <strong>
+                          {getFieldName(subblock.label, subblock.field_id)}
+                        </strong>
+                      </Segment>
                     )}
                     <BlockDataForm
                       schema={FieldSchema(subblock)}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
   Confirm,
   Dimmer,
   Loader,
+  Divider,
 } from 'semantic-ui-react';
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
@@ -30,6 +31,7 @@ import config from '@plone/volto/registry';
 
 import { BlockDataForm } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
+import { getFieldName } from 'volto-form-block/components/utils';
 
 const messages = defineMessages({
   exportCsv: {
@@ -51,6 +53,10 @@ const messages = defineMessages({
   cancel: {
     id: 'Cancel',
     defaultMessage: 'Cancel',
+  },
+  fieldId: {
+    id: 'fieldId',
+    defaultMessage: 'Field ID',
   },
 });
 
@@ -190,6 +196,33 @@ const Sidebar = ({
                     )}
                   </Accordion.Title>
                   <Accordion.Content active={selected === index}>
+                    {/* Field ID info */}
+                    {(subblock.field_type === 'text' ||
+                      subblock.field_type === 'from' ||
+                      subblock.field_type === 'textarea' ||
+                      subblock.field_type === 'date') && (
+                      <>
+                        <Form.Field inline>
+                          <Grid>
+                            <Grid.Row columns={2} style={{ margin: '1rem 0' }}>
+                              <Grid.Column width="4">
+                                {intl.formatMessage(messages.fieldId)}
+                              </Grid.Column>
+
+                              <Grid.Column width="8" style={{ opacity: '0.6' }}>
+                                <p>
+                                  {getFieldName(
+                                    subblock.label,
+                                    subblock.field_id,
+                                  )}
+                                </p>
+                                <Divider fitted />
+                              </Grid.Column>
+                            </Grid.Row>
+                          </Grid>
+                        </Form.Field>
+                      </>
+                    )}
                     <BlockDataForm
                       schema={FieldSchema(subblock)}
                       onChangeField={(name, value) => {

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -62,7 +62,7 @@ const messages = defineMessages({
   send_message_helptext: {
     id: 'form_send_message_helptext',
     defaultMessage:
-      'You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.',
+      'You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.',
   },
 });
 

--- a/src/formSchema.js
+++ b/src/formSchema.js
@@ -30,6 +30,14 @@ const messages = defineMessages({
     id: 'form_submit_label',
     defaultMessage: 'Submit button label',
   },
+  show_cancel: {
+    id: 'form_show_cancel',
+    defaultMessage: 'Show cancel button',
+  },
+  cancel_label: {
+    id: 'form_cancel_label',
+    defaultMessage: 'Cancel button label',
+  },
   captcha: {
     id: 'captcha',
     defaultMessage: 'Captcha provider',
@@ -47,9 +55,18 @@ const messages = defineMessages({
     id: 'form_send_email',
     defaultMessage: 'Send email to recipient',
   },
+  send_message: {
+    id: 'form_send_message',
+    defaultMessage: 'Message of sending confirmed',
+  },
+  send_message_helptext: {
+    id: 'form_send_message_helptext',
+    defaultMessage:
+      'You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id_xxx}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.',
+  },
 });
 
-export default () => {
+export default (data) => {
   var intl = useIntl();
 
   return {
@@ -65,9 +82,12 @@ export default () => {
           'default_from',
           'default_subject',
           'submit_label',
+          'show_cancel',
+          ...(data?.show_cancel ? ['cancel_label'] : []),
           'captcha',
           'store',
           'send',
+          'send_message',
         ],
       },
     ],
@@ -91,6 +111,14 @@ export default () => {
       submit_label: {
         title: intl.formatMessage(messages.submit_label),
       },
+      show_cancel: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.show_cancel),
+        default: false,
+      },
+      cancel_label: {
+        title: intl.formatMessage(messages.cancel_label),
+      },
       captcha: {
         title: intl.formatMessage(messages.captcha),
         type: 'string',
@@ -106,6 +134,11 @@ export default () => {
         type: 'boolean',
         title: intl.formatMessage(messages.send),
         description: intl.formatMessage(messages.attachmentSendEmail),
+      },
+      send_message: {
+        title: intl.formatMessage(messages.send_message),
+        type: 'textarea',
+        description: intl.formatMessage(messages.send_message_helptext),
       },
     },
     required: ['default_to', 'default_from', 'default_subject'],


### PR DESCRIPTION
Added a button to reset the form fields, by default it is not visible and it's possible customize its label.

<img width="1522" alt="Screenshot 2023-12-04 alle 10 28 42" src="https://github.com/collective/volto-form-block/assets/43245702/98bb31c9-94f0-494d-b5e9-702257f00987">


Added an user configurable message of sending confirmed.
The fields that can be used are text, textarea, date and email.

![Screenshot 2023-12-05 alle 12 20 44](https://github.com/collective/volto-form-block/assets/43245702/c6d6b27c-8a02-4a8c-84e9-f827ae4bfe43)

![Screenshot 2023-12-05 alle 12 22 00](https://github.com/collective/volto-form-block/assets/43245702/bfc1ced3-ed1a-439a-ad72-4daca346fac7)
