### PR TITLE
feat: added bcc email validation with otp code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ With HCaptcha integration, you also have an additional option in the sidebar in 
 
 In some test scenarios it's found that the "Passing Threshold" of HCaptcha must be configured as "Auto" to get the best results. In some test cases if one sets the Threshold to "Moderate" HCaptcha starts to fail.
 
+### OTP email validation
+
+To prevent sending spam emails to users via the email address configured as sender, the 'email' fields type flagged as BCC will require the user to enter an OTP code received at the address entered in the field when user fills out the form.
+
 ## Export
 
 With backend support, you can store data submitted from the form.

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Löschen"
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr "Beschriftung der Schaltfläche Senden"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Gesendet!"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr "Daten exportieren"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr "Textfeld"
 msgid "form_formDataCount"
 msgstr "{formDataCount} Element(e) gespeichert"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr "Setzt diese Adresse als Antwortadresse in versendeten Mails"
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr "Export in CSV"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr "Textarea"
 msgid "form_formDataCount"
 msgstr "{formDataCount} item(s) stored"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr "Message of sending confirmed"
 msgid "form_send_message_helptext"
 msgstr "You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting."
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr "If selected, this will be the address the receiver can use to reply."
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Clear"
@@ -494,7 +499,7 @@ msgstr "Show cancel button"
 msgid "form_submit_label"
 msgstr "Submit button label"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Sent!"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -443,6 +443,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -307,12 +307,12 @@ msgstr "Exportar datos"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -433,6 +433,11 @@ msgstr "Campo de texto"
 msgid "form_formDataCount"
 msgstr "{formDataCount} elemento(s) guardados"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -478,6 +483,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -521,6 +531,11 @@ msgstr "Si está seleccionado el valor de este campo se utilizará como cabecera
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -444,6 +444,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -458,7 +463,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Borrar"
@@ -503,7 +508,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr "Etiqueta del botón de envío"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Enviado"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -300,12 +300,12 @@ msgstr "Esportatu datuak"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -426,6 +426,11 @@ msgstr "Testua"
 msgid "form_formDataCount"
 msgstr "Gordetako elementu kopurua: {formDataCount}"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -471,6 +476,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -514,6 +524,11 @@ msgstr "Aukeratuz gero jasotako posta elektronikoari 'Erantzun' eginez gero erem
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -437,6 +437,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -451,7 +456,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Garbitu"
@@ -496,7 +501,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr "Bidalketa botoiaren etiketa"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Bidalita!"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -436,6 +436,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr "Exporter au format CSV"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr "Zone de texte"
 msgid "form_formDataCount"
 msgstr "{formDataCount} article(s) stocké(s)"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Dégager"
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr "Soumettre l'étiquette du bouton"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Expédié!"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr "Gestione dei dati"
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr "Puoi inviare un nuovo codice OTP fra"
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr "Il codice OTP è stato inviato a {email}. Verifica la tua email e inserisci nel campo sopra il codice OTP ricevuto."
@@ -449,7 +454,7 @@ msgstr "Giorni validità"
 msgid "form_remove_data_after_days_helptext"
 msgstr "Numero di giorni dopo i quali, i dati dovrebbero essere cancellati"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Indietro"
@@ -494,7 +499,7 @@ msgstr "Mostra il bottone annulla"
 msgid "form_submit_label"
 msgstr "Testo sul bottone di invio"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Inviato!"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr "Inserisci qui il codice OTP ricevuto all'indirizzo {email}"
 msgid "form_manage_data"
 msgstr "Gestione dei dati"
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr "Il codice OTP è stato inviato a {email}. Verifica la tua email e inserisci nel campo sopra il codice OTP ricevuto."
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr "Esporta in CSV"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr "Inserire i campi obbligatori per la configurazione del form nella sidebar di destra. Il form non verrà mostrato sul sito finché i campi obbligatori non saranno configurati."
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr "L'e-mail inserita nel campo 'Mittente di default' deve essere un indirizzo e-mail valido"
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr "Le e-mail inserite nel campo 'Destinatari' devono essere indirizzi e-mail validi."
@@ -424,6 +424,11 @@ msgstr "Area di testo"
 msgid "form_formDataCount"
 msgstr "{formDataCount} elementi salvati"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr "Inserisci qui il codice OTP ricevuto all'indirizzo {email}"
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr "Messaggio di conferma invio"
 msgid "form_send_message_helptext"
 msgstr "Si può aggiungere il valore di un campo compilato nella form inserendo il suo identificativo tra parentesi graffe preceduto da $, esempio: ${identificativo}; inoltre si possono aggiungere elementi html come link, <a..></a>, nuova linea <br />, formattazioni in bold <b> e italic <i>."
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr "Invia il codice OTP a {email}"
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -513,6 +523,11 @@ msgstr "Se selezionato, questo sarà l'indirizzo a cui il destinatario potrà ri
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
 msgstr "Il valore inserito non è valido"
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
+msgstr "Inserire il codice OTP ricevuto via email."
 
 #: components/View
 # defaultMessage: The email is incorrect

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr ""
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr ""
 msgid "form_formDataCount"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr ""
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr ""
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr ""
 msgid "form_formDataCount"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr ""
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr ""

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr ""
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr ""
 msgid "form_formDataCount"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr ""
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr ""

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -440,6 +440,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -441,6 +441,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -455,7 +460,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr "Limpar"
@@ -500,7 +505,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr "Texto do botão de enviar"
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Enviado!"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -304,12 +304,12 @@ msgstr "Exportar dados"
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -430,6 +430,11 @@ msgstr "Área de texto"
 msgid "form_formDataCount"
 msgstr "{formDataCount} item(ns) armazenados"
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -475,6 +480,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -518,6 +528,11 @@ msgstr "Usar este campo como valor do cabeçalho de 'responder para'"
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -298,12 +298,12 @@ msgstr ""
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -424,6 +424,11 @@ msgstr ""
 msgid "form_formDataCount"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -469,6 +474,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -512,6 +522,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -434,6 +434,11 @@ msgstr ""
 msgid "form_manage_data"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Data wipe
 msgid "form_remove_data_after_days"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -435,6 +435,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -449,7 +454,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr ""
@@ -494,7 +499,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-04-16T10:30:04.164Z\n"
+"POT-Creation-Date: 2024-04-17T08:56:51.659Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -437,6 +437,11 @@ msgid "form_manage_data"
 msgstr ""
 
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
+msgid "form_otp_countdown"
+msgstr ""
+
+#: components/Widget/OTPWidget
 # defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr ""
@@ -451,7 +456,7 @@ msgstr ""
 msgid "form_remove_data_after_days_helptext"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Clear
 msgid "form_reset"
 msgstr ""
@@ -496,7 +501,7 @@ msgstr ""
 msgid "form_submit_label"
 msgstr ""
 
-#: components/FormView
+#: components/FormResult
 # defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr ""

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-04-16T09:11:47.457Z\n"
+"POT-Creation-Date: 2024-04-16T10:30:04.164Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -434,6 +434,11 @@ msgstr ""
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
+msgstr ""
+
+#: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
+msgid "form_otp_send"
 msgstr ""
 
 #: formSchema

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-03-18T09:07:32.597Z\n"
+"POT-Creation-Date: 2024-04-16T09:11:47.457Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -300,12 +300,12 @@ msgstr ""
 msgid "form_edit_fill_required_configuration_fields"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr ""
 
-#: index
+#: helpers/validators
 # defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr ""
@@ -426,6 +426,11 @@ msgstr ""
 msgid "form_formDataCount"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
+msgid "form_insert_otp"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Manage data
 msgid "form_manage_data"
@@ -471,6 +476,11 @@ msgstr ""
 msgid "form_send_message_helptext"
 msgstr ""
 
+#: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
+msgid "form_send_otp_to"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Show cancel button
 msgid "form_show_cancel"
@@ -514,6 +524,11 @@ msgstr ""
 #: components/View
 # defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
+msgstr ""
+
+#: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
+msgid "formblock_insertOtp_error"
 msgstr ""
 
 #: components/View

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -85,3 +85,24 @@ export function clearFormData({ path, block_id, expired = false }) {
     },
   };
 }
+
+/**
+ * sendOTP action
+ * @module actions/sendOTP
+ */
+export const SEND_OTP = 'SEND_OTP';
+
+export function sendOTP(path, block_id, email) {
+  return {
+    type: SUBMIT_FORM_ACTION,
+    subrequest: block_id + '_' + email,
+    request: {
+      op: 'post',
+      path: path + '/@validate-email-address',
+      data: {
+        email,
+        uid: block_id,
+      },
+    },
+  };
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -94,7 +94,7 @@ export const SEND_OTP = 'SEND_OTP';
 
 export function sendOTP(path, block_id, email) {
   return {
-    type: SUBMIT_FORM_ACTION,
+    type: SEND_OTP,
     subrequest: block_id + '_' + email,
     request: {
       op: 'post',

--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -211,7 +211,8 @@ const FormView = ({
                   .map((subblock, index) => {
                     const fieldName = getFieldName(subblock.label, subblock.id);
                     const name = fieldName + OTP_FIELDNAME_EXTENDER;
-                    const fieldValue = formData[name]?.value;
+                    const fieldValue = formData[fieldName]?.value;
+                    const value = formData[fieldName]?.otp;
                     const fields_to_send_with_value =
                       getFieldsToSendWithValue(subblock);
 
@@ -221,7 +222,7 @@ const FormView = ({
                           <OTPWidget
                             {...subblock}
                             fieldValue={fieldValue}
-                            onChange={(value) =>
+                            onChange={(field, value) =>
                               onChangeFormData(
                                 subblock.id,
                                 fieldName,
@@ -232,7 +233,7 @@ const FormView = ({
                                 },
                               )
                             }
-                            value={formData[name]?.otp}
+                            value={value}
                             valid={isValidField(name)}
                             errorMessage={getErrorMessage(name)}
                             formHasErrors={formErrors?.length > 0}

--- a/src/components/Widget/Button.jsx
+++ b/src/components/Widget/Button.jsx
@@ -1,0 +1,13 @@
+/**
+ * Button component.
+ * This is a wrapper for Buttons, to eventually customize Button component if you don't like to use semantic-ui, for example.
+ * @module components/Widget/OTPWidget
+ */
+
+import { Button as SemanticButton } from 'semantic-ui-react';
+
+const Button = (props) => {
+  return <SemanticButton {...props} />;
+};
+
+export default Button;

--- a/src/components/Widget/FileWidget.jsx
+++ b/src/components/Widget/FileWidget.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Image, Dimmer } from 'semantic-ui-react';
+import { Image, Dimmer } from 'semantic-ui-react';
 import { readAsDataURL } from 'promise-file-reader';
 import { injectIntl } from 'react-intl';
 import deleteSVG from '@plone/volto/icons/delete.svg';
@@ -14,6 +14,7 @@ import { Icon, FormFieldWrapper } from '@plone/volto/components';
 import loadable from '@loadable/component';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { defineMessages, useIntl } from 'react-intl';
+import { Button } from 'volto-form-block/components/Widget';
 
 const imageMimetypes = [
   'image/png',
@@ -85,8 +86,8 @@ const FileWidget = (props) => {
   const imgsrc = value?.download
     ? `${flattenToAppURL(value?.download)}?id=${Date.now()}`
     : null || value?.data
-    ? `data:${value['content-type']};${value.encoding},${value.data}`
-    : null;
+      ? `data:${value['content-type']};${value.encoding},${value.data}`
+      : null;
 
   /**
    * Drop handler

--- a/src/components/Widget/OTPWidget.css
+++ b/src/components/Widget/OTPWidget.css
@@ -1,0 +1,28 @@
+.otp-widget .otp-widget-field-wrapper {
+    display: flex;
+    gap: 1rem;
+    align-items: start;
+}
+.otp-widget .otp-widget-field-wrapper .field {
+    flex-grow: 1;
+}
+
+.otp-widget .otp-send-error {
+    color: #d9364f;
+    padding: 1rem;
+    margin: 1rem;
+    border: 1px solid #d9364f;
+    width: 100%;
+    text-align: center;
+}
+
+@media (max-width: 1024px) {
+    .otp-widget .otp-widget-field-wrapper {
+        flex-direction: column;
+    }
+    .otp-widget .otp-widget-field-wrapper .field,
+    .otp-widget .otp-widget-field-wrapper .button-wrapper,
+    .otp-widget .otp-widget-field-wrapper .button-wrapper button {
+        width: 100%;
+    }
+}

--- a/src/components/Widget/OTPWidget.css
+++ b/src/components/Widget/OTPWidget.css
@@ -7,15 +7,25 @@
     flex-grow: 1;
 }
 
-.otp-widget .otp-send-error {
-    color: #d9364f;
-    padding: 1rem;
-    margin: 1rem;
-    border: 1px solid #d9364f;
-    width: 100%;
-    text-align: center;
+.otp-widget .otp-alert {
+    position: relative;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid #5d7083;
+    border-left: 8px solid #5d7083;
+    background-color: #fff;
+    border-radius: 0;
+    margin-top: -3rem;
+    margin-bottom: 3rem;
 }
 
+.otp-widget .otp-alert.otp-error {
+    border-left: 8px solid #cc334d;
+}
+
+.otp-widget .otp-alert.otp-success {
+    border-left: 8px solid #008055;
+}
 @media (max-width: 1024px) {
     .otp-widget .otp-widget-field-wrapper {
         flex-direction: column;

--- a/src/components/Widget/OTPWidget.css
+++ b/src/components/Widget/OTPWidget.css
@@ -26,6 +26,17 @@
 .otp-widget .otp-alert.otp-success {
     border-left: 8px solid #008055;
 }
+
+.otp-widget .otp-widget-field-wrapper .button-wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.otp-widget .otp-widget-field-wrapper .button-wrapper .otp-button-message {
+    font-size: 0.8rem;
+    color: #555555;
+    text-align: center;
+}
 @media (max-width: 1024px) {
     .otp-widget .otp-widget-field-wrapper {
         flex-direction: column;

--- a/src/components/Widget/OTPWidget.jsx
+++ b/src/components/Widget/OTPWidget.jsx
@@ -24,6 +24,11 @@ const messages = defineMessages({
     id: 'form_insert_otp',
     defaultMessage: 'Insert here the OTP code received at {email}',
   },
+  otp_sent: {
+    id: 'form_otp_send',
+    defaultMessage:
+      'OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.',
+  },
 });
 
 const OTPWidget = (props) => {
@@ -91,8 +96,14 @@ const OTPWidget = (props) => {
         />
       </div>
 
+      {sendOTPResponse?.loaded && !sendOTPResponse?.loading && (
+        <div className="otp-alert otp-success">
+          {intl.formatMessage(messages.otp_sent, { email: fieldValue })}
+        </div>
+      )}
+
       {sendOTPResponse?.error && (
-        <div className="otp-send-error">
+        <div className="otp-alert otp-error">
           {JSON.stringify(sendOTPResponse.error)}
         </div>
       )}

--- a/src/components/Widget/OTPWidget.jsx
+++ b/src/components/Widget/OTPWidget.jsx
@@ -1,0 +1,142 @@
+/**
+ * OTPWidget component.
+ * @module components/Widget/OTPWidget
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useIntl, defineMessages } from 'react-intl';
+import { isValidEmail } from 'volto-form-block/helpers/validators';
+import Field from 'volto-form-block/components/Field';
+import { Button } from 'volto-form-block/components/Widget';
+import { sendOTP } from 'volto-form-block/actions';
+
+import 'volto-form-block/components/Widget/OTPWidget.css';
+export const OTP_FIELDNAME_EXTENDER = '_otp';
+
+const messages = defineMessages({
+  send_otp_to: {
+    id: 'form_send_otp_to',
+    defaultMessage: 'Send OTP code to {email}',
+  },
+  insert_otp: {
+    id: 'form_insert_otp',
+    defaultMessage: 'Insert here the OTP code received at {email}',
+  },
+});
+
+const OTPWidget = (props) => {
+  const {
+    id,
+    title,
+    fieldValue,
+    onChange,
+    value,
+    valid,
+    disabled,
+    isOnEdit,
+    formHasErrors,
+    errorMessage,
+    path,
+    block_id,
+  } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const _id = id + OTP_FIELDNAME_EXTENDER;
+  const sendOTPResponse = useSelector(
+    (state) => state.sendOTP?.subrequests?.[block_id + '_' + fieldValue],
+  );
+
+  const displayWidget = isValidEmail(fieldValue);
+
+  const sendOTPCode = () => {
+    dispatch(sendOTP(path, block_id, fieldValue));
+  };
+
+  return displayWidget ? (
+    <div className="otp-widget">
+      <div className="otp-widget-field-wrapper">
+        <div className="button-wrapper">
+          <Button
+            basic
+            size="mini"
+            primary
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              sendOTPCode();
+            }}
+            className="send-otp-code"
+          >
+            {intl.formatMessage(messages.send_otp_to, { email: fieldValue })}
+          </Button>
+        </div>
+        <Field
+          label={
+            title ??
+            intl.formatMessage(messages.insert_otp, { email: fieldValue })
+          }
+          name={_id}
+          id={id}
+          field_type="text"
+          required={true}
+          value={value || ''}
+          onChange={onChange}
+          valid={valid}
+          disabled={disabled}
+          formHasErrors={formHasErrors}
+          errorMessage={errorMessage}
+          isOnEdit={isOnEdit}
+        />
+      </div>
+
+      {sendOTPResponse?.error && (
+        <div className="otp-send-error">
+          {JSON.stringify(sendOTPResponse.error)}
+        </div>
+      )}
+    </div>
+  ) : (
+    <></>
+  );
+};
+
+/**
+ * Property types
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+OTPWidget.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
+  onClick: PropTypes.func,
+  minLength: PropTypes.number,
+  maxLength: PropTypes.number,
+  placeholder: PropTypes.string,
+};
+
+/**
+ * Default properties.
+ * @property {Object} defaultProps Default properties.
+ * @static
+ */
+OTPWidget.defaultProps = {
+  description: null,
+  required: false,
+  error: [],
+  value: null,
+  onChange: () => {},
+  onBlur: () => {},
+  onClick: () => {},
+  minLength: null,
+  maxLength: null,
+};
+
+export default OTPWidget;

--- a/src/components/Widget/OTPWidget.jsx
+++ b/src/components/Widget/OTPWidget.jsx
@@ -116,7 +116,7 @@ const OTPWidget = (props) => {
             <div className="otp-button-message">
               {intl.formatMessage(messages.otp_countdown)}{' '}
               {getCountDownValues(countDown)
-                .filter((v, index) => v > 0 || index === 2)
+                .filter((v, index) => v > 0 || index === 2 || index === 3)
                 .map((v) => (v < 10 ? '0' + v : v))
                 .join(':')}
               .

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -13,3 +13,6 @@ export { default as RadioWidget } from 'volto-form-block/components/Widget/Radio
 export { default as SelectWidget } from 'volto-form-block/components/Widget/SelectWidget';
 export { default as TextareaWidget } from 'volto-form-block/components/Widget/TextareaWidget';
 export { default as TextWidget } from 'volto-form-block/components/Widget/TextWidget';
+export { default as OTPWidget } from 'volto-form-block/components/Widget/OTPWidget';
+export { OTP_FIELDNAME_EXTENDER } from 'volto-form-block/components/Widget/OTPWidget';
+export { default as Button } from 'volto-form-block/components/Widget/Button';

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import {
   getFormData,
   exportCsvFormData,
   clearFormData,
+  sendOTP,
 } from 'volto-form-block/reducers';
 import FormSchema from 'volto-form-block/formSchema';
 import FieldSchema from 'volto-form-block/fieldSchema';
@@ -34,6 +35,7 @@ export {
   submitForm,
   getFormData,
   exportCsvFormData,
+  sendOTP,
 } from 'volto-form-block/actions';
 export { isValidEmail };
 
@@ -83,13 +85,14 @@ const applyConfig = (config) => {
     formData: getFormData,
     exportCsvFormData,
     clearFormData,
+    sendOTP,
   };
 
-  config.settings.loadables['HCaptcha'] = loadable(() =>
-    import('@hcaptcha/react-hcaptcha'),
+  config.settings.loadables['HCaptcha'] = loadable(
+    () => import('@hcaptcha/react-hcaptcha'),
   );
-  config.settings.loadables['GoogleReCaptcha'] = loadable.lib(() =>
-    import('react-google-recaptcha-v3'),
+  config.settings.loadables['GoogleReCaptcha'] = loadable.lib(
+    () => import('react-google-recaptcha-v3'),
   );
 
   return config;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,6 +7,7 @@ import {
   EXPORT_CSV_FORMDATA,
   GET_FORM_DATA,
   CLEAR_FORM_DATA,
+  SEND_OTP,
 } from 'volto-form-block/actions';
 
 function download(filename, text) {
@@ -219,6 +220,85 @@ export const clearFormData = (state = initialState, action = {}) => {
         loaded: false,
         loading: false,
       };
+    default:
+      return state;
+  }
+};
+
+/**
+ * sendOTP reducer.
+ * @function sendOTP
+ * @param {Object} state Current state.
+ * @param {Object} action Action to be handled.
+ * @returns {Object} New state.
+ */
+export const sendOTP = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case `${SEND_OTP}_PENDING`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                ...(state.subrequests[action.subrequest] || {
+                  items: [],
+                  total: 0,
+                  batching: {},
+                }),
+                error: null,
+                loaded: false,
+                loading: true,
+              },
+            },
+          }
+        : {
+            ...state,
+            error: null,
+            loading: true,
+            loaded: false,
+          };
+    case `${SEND_OTP}_SUCCESS`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                ...(state.subrequests[action.subrequest] || {}),
+                error: null,
+                loaded: true,
+                loading: false,
+              },
+            },
+          }
+        : {
+            ...state,
+            error: null,
+            loaded: true,
+            loading: false,
+          };
+    case `${SEND_OTP}_FAIL`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                ...(state.subrequests[action.subrequest] || {}),
+                error: action.error,
+                loading: false,
+                loaded: false,
+              },
+            },
+          }
+        : {
+            ...state,
+            error: action.error,
+            loading: false,
+            loaded: false,
+          };
+
     default:
       return state;
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -95,6 +95,7 @@ export const submitForm = (state = initialState, action = {}) => {
               ...state.subrequests,
               [action.subrequest]: {
                 ...(state.subrequests[action.subrequest] || {}),
+                error: action.error,
                 loading: false,
                 loaded: false,
               },


### PR DESCRIPTION
For fields of type "form" and type "email" setted as BCC,
we now add validation email with OTP code to prevent security problems
https://github.com/collective/volto-form-block/assets/51911425/92d8e987-71e5-4f58-b4e4-e1facaf90367

needs  https://github.com/collective/collective.volto.formsupport/pull/48

