### PR TITLE
fix: error on form submit: Objects are not valid as a React child.

### DIFF
--- a/src/components/View.jsx
+++ b/src/components/View.jsx
@@ -295,10 +295,10 @@ const View = ({ data, id, path }) => {
     if (submitResults?.loaded) {
       setFormState({
         type: FORM_STATES.success,
-        result: {
-          message: intl.formatMessage(messages.formSubmitted),
-          ...submitResults.result,
-        },
+        result: [
+          intl.formatMessage(messages.formSubmitted),
+          submitResults.result
+        ]
       });
       captcha.reset();
       const formItem = document.getElementById(formid);


### PR DESCRIPTION
Fixes https://github.com/collective/volto-form-block/issues/96

The error was raised on [this line](https://github.com/collective/volto-form-block/blob/v3.8.2/src/components/FormResult.jsx#L47):

    <p>{formState.result}</p>

Apparently in that case, `formState.result` should either be a string or a list (or I guess a component), but in this case it was an Object.  With my Python background I still want to call that not an object, but a dictionary. ;-)