### PR TITLE
Fix `align-items: start` in CSS - Makes autoprefixer happy :/

### DIFF
--- a/src/components/Widget/OTPWidget.css
+++ b/src/components/Widget/OTPWidget.css
@@ -1,7 +1,7 @@
 .otp-widget .otp-widget-field-wrapper {
     display: flex;
     gap: 1rem;
-    align-items: start;
+    align-items: flex-start;
 }
 .otp-widget .otp-widget-field-wrapper .field {
     flex-grow: 1;


### PR DESCRIPTION
Webpack complains (in the new generator setup)

```
WARNING in ./node_modules/volto-form-block/src/components/Widget/OTPWidget.css (./node_modules/css-loader/dist/cjs.js??razzle-css-loader!./node_modules/razzle/node_modules/postcss-loader/dist/cjs.js??razzle-postcss-loader!./node_modules/volto-form-block/src/components/Widget/OTPWidget.css)
Module Warning (from ./node_modules/razzle/node_modules/postcss-loader/dist/cjs.js):
Warning

(4:5) autoprefixer: start value has mixed support, consider using flex-start instead
```

this makes `autoprefixer` happy.