### PR TITLE
fix: error on form submit: Objects are not valid as a React child.

### DIFF
--- a/src/components/FormResult.jsx
+++ b/src/components/FormResult.jsx
@@ -35,7 +35,7 @@ const FormResult = ({ formState, data, resetFormState }) => {
       {data.send_message ? (
         <p
           dangerouslySetInnerHTML={{
-            __html: replaceMessage(data.send_message, formState.result.data),
+            __html: replaceMessage(data.send_message, formState.result[1].data),
           }}
         />
       ) : (
@@ -44,7 +44,7 @@ const FormResult = ({ formState, data, resetFormState }) => {
           <Message.Header as="h4">
             {intl.formatMessage(messages.success)}
           </Message.Header>
-          <p>{formState.result}</p>
+          <p>{formState.result[0]}</p>
         </>
       )}
       {/* Back button */}


### PR DESCRIPTION
Fixing #96 (again), as described here: https://github.com/collective/volto-form-block/issues/96#issuecomment-2165428539