### PR TITLE
feat: added RAC components + autocomplete attr to all applicable fields

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -79,7 +79,7 @@ msgstr "Formular"
 #: components/Widget/HCaptchaWidget
 # defaultMessage: This site is protected by hCaptcha and its <a href="https://www.hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://www.hcaptcha.com/terms">Terms of Service</a> apply.
 msgid "HCaptchaInvisibleInfo"
-msgstr "Diese Website ist durch hCaptcha geschützt und es gelten die <a href=\"https://www.hcaptcha.com/privacy\">Datenschutzbestimmungen</a> und <a href=\"https://www.hcaptcha.com/terms\">Nutzungsbedingungen</a>."
+msgstr "Diese Website ist durch hCaptcha geschützt und es gelten die <a href="https://www.hcaptcha.com/privacy">Datenschutzbestimmungen</a> und <a href="https://www.hcaptcha.com/terms">Nutzungsbedingungen</a>."
 
 #: components/Widget/SelectWidget
 # defaultMessage: No value
@@ -235,6 +235,246 @@ msgstr "Beschreibung"
 # defaultMessage: Field ID
 msgid "fieldId"
 msgstr "Feld-ID"
+
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
 
 #: formSchema
 # defaultMessage: Form

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr "Description"
 msgid "fieldId"
 msgstr "Field ID"
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -245,6 +245,246 @@ msgstr "Descripción"
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -238,6 +238,246 @@ msgstr "Deskribapena"
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr ""
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -244,7 +244,7 @@ msgstr "Attributo 'autocomplete'"
 #: fieldSchema
 # defaultMessage: Additional name
 msgid "field_autocomplete_additional_name"
-msgstr "Questa opzione aggiunge l'attributo 'autocomplete' al campo. Questo attrivuto permette al browser di compilare automaticamente il campo con le informazioni dell'utente, se presenti. Per consultare la lista completa degli attributi e il loro uso, visita <a>questa pagina</a>"
+msgstr "Secondo nome"
 
 #: fieldSchema
 # defaultMessage: Address line 1
@@ -349,7 +349,7 @@ msgstr "Password attuale"
 #: fieldSchema
 # defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
 msgid "field_autocomplete_description"
-msgstr "Questo campo aggiunge l'attributo "autocomplete" al campo. Ciò consente al browser di compilare automaticamente il campo con le informazioni dell'utente, se memorizzate. Per un elenco completo di questi attributi e del loro utilizzo, visita <a>questa pagina</a>."
+msgstr "Questo campo aggiunge l'attributo 'autocomplete' al campo. Ciò consente al browser di compilare automaticamente il campo con le informazioni dell'utente, se memorizzate. Per un elenco completo di questi attributi e del loro utilizzo, visita <a>questa pagina</a>."
 
 #: fieldSchema
 # defaultMessage: Email

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr "Descrizione"
 msgid "fieldId"
 msgstr "Identificativo"
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr "Attributo 'autocomplete'"
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr "Questa opzione aggiunge l'attributo 'autocomplete' al campo. Questo attrivuto permette al browser di compilare automaticamente il campo con le informazioni dell'utente, se presenti. Per consultare la lista completa degli attributi e il loro uso, visita <a>questa pagina</a>"
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr "Indirizzo riga 1"
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr "Indirizzo riga 2"
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr "Indirizzo riga 3"
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr "Data di nascita"
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr "Giorno di nascita"
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr "Mese di nascita"
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr "Anno di nascita"
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr "Secondo nome del titolare della carta"
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr "Codice di sicurezza della carta di credito"
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr "Data di scadenza della carta di credito"
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr "Mese di scadenza della carta di credito"
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr "Anno di scadenza della carta di credito"
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr "Cognome del titolare della carta"
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr "Nome del titolare della carta"
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr "Nome del titolare della carta"
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr "Numero della carta di credito"
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr "Tipo di carta di credito"
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr "Paese"
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr "Nome del paese"
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr "Password attuale"
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr "Questo campo aggiunge l'attributo "autocomplete" al campo. Ciò consente al browser di compilare automaticamente il campo con le informazioni dell'utente, se memorizzate. Per un elenco completo di questi attributi e del loro utilizzo, visita <a>questa pagina</a>."
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr "Email"
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr "Cognome"
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr "Nome"
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr "Prefisso (es. sig., sig.ra)"
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr "Suffisso (es. jr, sr)"
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr "Lingua"
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr "Nome completo"
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr "Nuova password"
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr "Soprannome"
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr "Organizzazione"
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr "Titolo dell'organizzazione"
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr "Foto"
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr "Codice postale"
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr "Genere"
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr "Indirizzo"
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr "Numero di telefono"
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr "Prefisso telefonico"
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr "Prefisso internazionale"
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr "Interno telefonico"
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr "Numero telefonico locale"
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr "Numero telefonico nazionale"
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr "Importo della transazione"
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr "Valuta della transazione"
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr "URL del sito web"
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr "Nome utente"
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr ""
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr ""
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr ""
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -5,605 +5,847 @@ msgstr ""
 "POT-Creation-Date: 2017-04-27T19:30:59.079Z\n"
 "PO-Revision-Date: 2024-08-31 14:28-0300\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>\n"
-"Language-Team: Portuguese (https://www.transifex.com/plone/teams/14552/pt/)\n"
 "Language: pt_BR\n"
-"MIME-Version: 1.0\n"
+"Language-Team: Portuguese (https://www.transifex.com/plone/teams/14552/pt/)\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
 "Language-Code: pt-br\n"
 "Language-Name: Português do Brasil\n"
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
 "X-Generator: Poedit 3.4.4\n"
 
-# defaultMessage: Aggiungi un campo
 #: components/Edit
+# defaultMessage: Aggiungi un campo
 msgid "Add field"
 msgstr "Adicionar campo"
 
-# defaultMessage: Cancel
 #: components/Sidebar
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Cancelar"
 
-# defaultMessage: Choices
 #: components/Widget/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Opções"
 
-# defaultMessage: Choose a file
 #: components/Widget/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Escolha um arquivo"
 
-# defaultMessage: Close
 #: components/Widget/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Fechar"
 
-# defaultMessage: Date
 #: components/Widget/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
-# defaultMessage: Default
 #: components/Widget/SelectWidget
+# defaultMessage: Default
 msgid "Default"
 msgstr "Padrão"
 
-# defaultMessage: Description
 #: components/Widget/SelectWidget
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descrição"
 
-# defaultMessage: Drop file here to replace the existing file
 #: components/Widget/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Solte um arquivo aqui para substituir o arquivo existente"
 
-# defaultMessage: Drop file here to upload a new file
 #: components/Widget/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Solte um arquivo aqui para enviar um novo arquivo"
 
-# defaultMessage: Drop files here ...
 #: components/Widget/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Soltar aquivos aqui…"
 
-# defaultMessage: Error
 #: components/FormView
+# defaultMessage: Error
 msgid "Error"
 msgstr "Erro"
 
-# defaultMessage: Form
 #: components/Sidebar
+# defaultMessage: Form
 msgid "Form"
 msgstr "Formulário"
 
-# defaultMessage: This site is protected by hCaptcha and its <a href="https://www.hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://www.hcaptcha.com/terms">Terms of Service</a> apply.
 #: components/Widget/HCaptchaWidget
+# defaultMessage: This site is protected by hCaptcha and its <a href="https://www.hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://www.hcaptcha.com/terms">Terms of Service</a> apply.
 msgid "HCaptchaInvisibleInfo"
 msgstr "Este site é protegido pelo hCaptcha e sua <a href=“https://www.hcaptcha.com/privacy”>política de privacidade</a> e <a href=“https://www.hcaptcha.com/terms”>termos de serviço</a> se aplicam."
 
-# defaultMessage: No value
 #: components/Widget/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Sem valor"
 
-# defaultMessage: Replace existing file
 #: components/Widget/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Substituir o arquivo existente"
 
-# defaultMessage: Required
 #: components/Widget/SelectWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obrigatório"
 
-# defaultMessage: Select…
 #: components/Widget/SelectWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Selecione…"
 
-# defaultMessage: Time
 #: components/Widget/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Hora"
 
-# defaultMessage: Title
 #: components/Widget/SelectWidget
+# defaultMessage: Title
 msgid "Title"
 msgstr "Título"
 
-# defaultMessage: Used for programmatic access to the fieldset.
 #: components/Widget/SelectWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usado para acesso programático ao conjunto de campos."
 
-# defaultMessage: Use Up and Down to choose options
 #: helpers/react-select
+# defaultMessage: Use Up and Down to choose options
 msgid "ay11_Use Up and Down to choose options"
 msgstr "Use as setas para Cima e para Baixo para escolher as opções."
 
-# defaultMessage: available
 #: helpers/react-select
+# defaultMessage: available
 msgid "ay11_select available"
 msgstr "Disponível"
 
-# defaultMessage: availables
 #: helpers/react-select
+# defaultMessage: availables
 msgid "ay11_select availables"
 msgstr "disponíveis"
 
-# defaultMessage: deselected
 #: helpers/react-select
+# defaultMessage: deselected
 msgid "ay11_select deselected"
 msgstr "desselecionado"
 
-# defaultMessage: disabled
 #: helpers/react-select
+# defaultMessage: disabled
 msgid "ay11_select disabled"
 msgstr "desabilitado"
 
-# defaultMessage: focused
 #: helpers/react-select
+# defaultMessage: focused
 msgid "ay11_select focused"
 msgstr "em foco "
 
-# defaultMessage: for search term
 #: helpers/react-select
+# defaultMessage: for search term
 msgid "ay11_select for search term"
 msgstr "para termo de busca "
 
-# defaultMessage: is disabled. Select another option.
 #: helpers/react-select
+# defaultMessage: is disabled. Select another option.
 msgid "ay11_select is disabled. Select another option."
 msgstr "está desabilitado. Selecione outra opção. "
 
-# defaultMessage: option
 #: helpers/react-select
+# defaultMessage: option
 msgid "ay11_select option"
 msgstr "opção"
 
-# defaultMessage: result
 #: helpers/react-select
+# defaultMessage: result
 msgid "ay11_select result"
 msgstr "resultado"
 
-# defaultMessage: results
 #: helpers/react-select
+# defaultMessage: results
 msgid "ay11_select results"
 msgstr "resultados"
 
-# defaultMessage: selected
 #: helpers/react-select
+# defaultMessage: selected
 msgid "ay11_select selected"
 msgstr "selecionado"
 
-# defaultMessage: value
 #: helpers/react-select
+# defaultMessage: value
 msgid "ay11_select value"
 msgstr "valor"
 
-# defaultMessage: Use left and right to toggle between focused values, press Backspace to remove the currently focused value
 #: helpers/react-select
+# defaultMessage: Use left and right to toggle between focused values, press Backspace to remove the currently focused value
 msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
 msgstr "Use as setas esquerda e direita para alternar entre os valores focados, pressione Backspace para remover o valor atualmente focado."
 
-# defaultMessage: press Tab to select the option and exit the menu
 #: helpers/react-select
+# defaultMessage: press Tab to select the option and exit the menu
 msgid "ay11_select__press Tab to select the option and exit the menu"
 msgstr "pressione Tab para selecionar a opção e sair do menu"
 
-# defaultMessage: type to refine list
 #: helpers/react-select
+# defaultMessage: type to refine list
 msgid "ay11_select__type to refine list"
 msgstr "digite para refinar a lista "
 
-# defaultMessage: is_focused
 #: helpers/react-select
+# defaultMessage: is_focused
 msgid "ay11_select_is_focused"
 msgstr "está em foco "
 
-# defaultMessage: press Down to open the menu
 #: helpers/react-select
+# defaultMessage: press Down to open the menu
 msgid "ay11_select_press Down to open the menu"
 msgstr "pressione para Baixo para abrir o menu"
 
-# defaultMessage: press Enter to select the currently focused option
 #: helpers/react-select
+# defaultMessage: press Enter to select the currently focused option
 msgid "ay11_select_press Enter to select the currently focused option"
 msgstr "pressione Enter para selecionar a opção atualmente focada"
 
-# defaultMessage: press Escape to exit the menu
 #: helpers/react-select
+# defaultMessage: press Escape to exit the menu
 msgid "ay11_select_press Escape to exit the menu"
 msgstr "pressione ESC para sair do menu "
 
-# defaultMessage: press left to focus selected values
 #: helpers/react-select
+# defaultMessage: press left to focus selected values
 msgid "ay11_select_press left to focus selected values"
 msgstr "pressione Esquerda para focar nos valores selecionados "
 
-# defaultMessage: Captcha provider
 #: formSchema
+# defaultMessage: Captcha provider
 msgid "captcha"
 msgstr "Provedor de Captcha"
 
-# defaultMessage: Description
 #: formSchema
+# defaultMessage: Description
 msgid "description"
 msgstr "descrição"
 
-# defaultMessage: Field ID
 #: components/Sidebar
+# defaultMessage: Field ID
 msgid "fieldId"
 msgstr "Id do campo"
 
-# defaultMessage: Form
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
+# defaultMessage: Form
 msgid "form"
 msgstr "Formulário"
 
-# defaultMessage: Form successfully submitted
 #: components/View
+# defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "Formulário enviado com sucesso"
 
-# defaultMessage: Attached file will be sent via email, but not stored
 #: formSchema
+# defaultMessage: Attached file will be sent via email, but not stored
 msgid "form_attachment_send_email_info_text"
 msgstr "O arquivo anexado será enviado por e-mail, mas não será armazenado."
 
-# defaultMessage: Cancel button label
 #: formSchema
+# defaultMessage: Cancel button label
 msgid "form_cancel_label"
 msgstr "Etiqueta do botão de cancelar"
 
-# defaultMessage: Clear data
 #: components/Sidebar
+# defaultMessage: Clear data
 msgid "form_clear_data"
 msgstr "Limpar dados"
 
-# defaultMessage: Are you sure you want to delete all saved items?
 #: components/Sidebar
+# defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "Você tem certeza que deseja apagar todos as respostas salvas?"
 
+#: components/Edit
+#: components/FormView
 # defaultMessage: Annulla
-#: components/Edit components/FormView
 msgid "form_default_cancel_label"
 msgstr "Cancelar"
 
-# defaultMessage: Default sender
 #: formSchema
+# defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Remetente padrão"
 
-# defaultMessage: Mail subject
 #: formSchema
+# defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Assunto do e-mail"
 
-# defaultMessage: Use the ${field_id} syntax to add a form value to the email subject
 #: formSchema
+# defaultMessage: Use the ${field_id} syntax to add a form value to the email subject
 msgid "form_default_subject_description"
 msgstr "Use a sintaxe ${id_campo} para adicionar um valor do formulário ao assunto do e-mail."
 
+#: components/Edit
+#: components/FormView
 # defaultMessage: Invia
-#: components/Edit components/FormView
 msgid "form_default_submit_label"
 msgstr "Enviar"
 
-# defaultMessage: Export data
 #: components/Sidebar
+# defaultMessage: Export data
 msgid "form_edit_exportCsv"
 msgstr "Exportar dados"
 
-# defaultMessage: Please, fill-in required configuration fields in sidebar. The form will be not displayed in view mode until required fields are filled-in.
 #: components/ValidateConfigForm
+# defaultMessage: Please, fill-in required configuration fields in sidebar. The form will be not displayed in view mode until required fields are filled-in.
 msgid "form_edit_fill_required_configuration_fields"
 msgstr "Por favor, preencha os campos de configuração obrigatórios na barra lateral. O formulário não será exibido no modo de visualização até que os campos obrigatórios sejam preenchidos."
 
-# defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 #: helpers/validators
+# defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr "O e-mail inserido no campo ‘De’ deve ser um endereço de e-mail válido."
 
-# defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 #: helpers/validators
+# defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr "Os e-mails inseridos no campo ‘Destinatários’ devem ser endereços de e-mail válidos."
 
-# defaultMessage: Please, verify this configuration errors in sidebar. The form will be not displayed in view mode until this errors fields are not fixed.
 #: components/ValidateConfigForm
+# defaultMessage: Please, verify this configuration errors in sidebar. The form will be not displayed in view mode until this errors fields are not fixed.
 msgid "form_edit_other_errors"
 msgstr "Por favor, verifique esses erros de configuração na barra lateral. O formulário não será exibido no modo de visualização até que esses campos com erro sejam corrigidos."
 
-# defaultMessage: Attenzione!
 #: components/Edit
+# defaultMessage: Attenzione!
 msgid "form_edit_warning"
 msgstr "Atenção"
 
-# defaultMessage: Enter a field of type 'Sender E-mail'. If it is not present, or it is present but not filled in by the user, the sender address of the e-mail will be the one configured in the right sidebar.
 #: components/Edit
+# defaultMessage: Enter a field of type 'Sender E-mail'. If it is not present, or it is present but not filled in by the user, the sender address of the e-mail will be the one configured in the right sidebar.
 msgid "form_edit_warning_from"
 msgstr "Digite um campo do tipo 'E-mail do remetente'. Se não estiver presente, ou estiver presente mas não for preenchido pelo usuário, o endereço do remetente do e-mail será o configurado na barra lateral direita."
 
-# defaultMessage: There are some errors in the form.
 #: components/FormView
+# defaultMessage: There are some errors in the form.
 msgid "form_errors_validation"
 msgstr "Existem erros nesse formulário."
 
-# defaultMessage: Description
 #: fieldSchema
+# defaultMessage: Description
 msgid "form_field_description"
 msgstr "Descrição"
 
-# defaultMessage: Value for field
 #: components/FieldTypeSchemaExtenders/HiddenSchemaExtender
+# defaultMessage: Value for field
 msgid "form_field_input_value"
 msgstr "Valor para o campo"
 
-# defaultMessage: Possible values
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
 #: components/FieldTypeSchemaExtenders/SelectionSchemaExtender
+# defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valores possíveis"
 
-# defaultMessage: Label
 #: fieldSchema
+# defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etiqueta"
 
-# defaultMessage: Required
 #: fieldSchema
+# defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obrigatório"
 
-# defaultMessage: Field type
 #: fieldSchema
+# defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Tipo de campo"
 
-# defaultMessage: Attachment
 #: fieldSchema
+# defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Anexo"
 
-# defaultMessage: Any attachments can be emailed, but will not be saved.
 #: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
 msgid "form_field_type_attachment_info_text"
 msgstr "Qualquer anexo pode ser enviado por e-mail, mas não será salvo."
 
-# defaultMessage: Checkbox
 #: fieldSchema
+# defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Múltipla escolha"
 
-# defaultMessage: Date
 #: fieldSchema
+# defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Data"
 
-# defaultMessage: E-mail
 #: fieldSchema
+# defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "E-mail"
 
-# defaultMessage: Hidden
 #: fieldSchema
+# defaultMessage: Hidden
 msgid "form_field_type_hidden"
 msgstr "Oculto"
 
-# defaultMessage: Multiple choice
 #: fieldSchema
+# defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Múltipla escolha"
 
-# defaultMessage: List
 #: fieldSchema
+# defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Opções"
 
-# defaultMessage: Single choice
 #: fieldSchema
+# defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Escolha única"
 
-# defaultMessage: Static text
 #: fieldSchema
+# defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Texto estático"
 
-# defaultMessage: Text
 #: fieldSchema
+# defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Texto"
 
-# defaultMessage: Textarea
 #: fieldSchema
+# defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Área de texto"
 
-# defaultMessage: {formDataCount} item(s) stored
 #: components/Sidebar
+# defaultMessage: {formDataCount} item(s) stored
 msgid "form_formDataCount"
 msgstr "{formDataCount} item(ns) armazenados"
 
-# defaultMessage: Insert here the OTP code received at {email}
 #: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
 msgid "form_insert_otp"
 msgstr "Insira aqui o código OTP recebido em {email}."
 
-# defaultMessage: Manage data
 #: formSchema
+# defaultMessage: Manage data
 msgid "form_manage_data"
 msgstr "Gerenciar dados"
 
-# defaultMessage: You can send a new OTP code in
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
 msgid "form_otp_countdown"
 msgstr "Você pode enviar um novo código OTP em"
 
-# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 #: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr "O código OTP foi enviado para {email}. Verifique seu e-mail e insira o código OTP recebido no campo acima."
 
-# defaultMessage: Data wipe
 #: formSchema
+# defaultMessage: Data wipe
 msgid "form_remove_data_after_days"
 msgstr "Exclusão dos dados"
 
-# defaultMessage: Number of days after which, the data should be deleted
 #: formSchema
+# defaultMessage: Number of days after which, the data should be deleted
 msgid "form_remove_data_after_days_helptext"
 msgstr "Número de dias após os quais os dados devem ser excluídos."
 
-# defaultMessage: Clear
 #: components/FormResult
+# defaultMessage: Clear
 msgid "form_reset"
 msgstr "Limpar"
 
-# defaultMessage: Store compiled data
 #: formSchema
+# defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Armazenar dados"
 
-# defaultMessage: Select a value
 #: components/Field
+# defaultMessage: Select a value
 msgid "form_select_a_value"
 msgstr "Selecione um valor"
 
-# defaultMessage: Send email to recipient
 #: formSchema
+# defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar e-mail para o destinatário"
 
-# defaultMessage: Message of sending confirmed
 #: formSchema
+# defaultMessage: Message of sending confirmed
 msgid "form_send_message"
 msgstr "Mensagem de envio confirmada."
 
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 #: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr "Você pode adicionar o valor de um campo preenchido no formulário inserindo seu ID entre chaves precedido por $, exemplo: ${field_id}; você também pode adicionar elementos HTML, como links <a>, nova linha <br />, formatação em negrito <b> e itálico <i>."
 
-# defaultMessage: Send OTP code to {email}
 #: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
 msgid "form_send_otp_to"
 msgstr "Enviar código OTP para {email}."
 
-# defaultMessage: Show cancel button
 #: formSchema
+# defaultMessage: Show cancel button
 msgid "form_show_cancel"
 msgstr "Mostrar botão de cancelar"
 
-# defaultMessage: Submit button label
 #: formSchema
+# defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Texto do botão de enviar"
 
-# defaultMessage: Sent!
 #: components/FormResult
+# defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Enviado!"
 
-# defaultMessage: Recipients
 #: formSchema
+# defaultMessage: Recipients
 msgid "form_to"
 msgstr "Destinatários"
 
-# defaultMessage: Send an email copy to this address
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Send an email copy to this address
 msgid "form_useAsBCC"
 msgstr "Enviar uma cópia do e-mail para este endereço"
 
-# defaultMessage: If selected, a copy of email will alse be sent to this address.
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, a copy of email will alse be sent to this address.
 msgid "form_useAsBCC_description"
 msgstr "Caso selecionado, uma cópia do e-mail também será enviada para este endereço."
 
-# defaultMessage: Use as 'reply to'
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'responder para'"
 
-# defaultMessage: If selected, this will be the address the receiver can use to reply.
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will be the address the receiver can use to reply.
 msgid "form_useAsReplyTo_description"
 msgstr "Usar este campo como valor do cabeçalho de 'responder para'"
 
-# defaultMessage: Invalid field value
 #: components/View
+# defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
 msgstr "Valor inválido para o campo"
 
-# defaultMessage: Please, insert the OTP code recived via email.
 #: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
 msgid "formblock_insertOtp_error"
 msgstr "Por favor informe o código OTP recebido"
 
-# defaultMessage: The email is incorrect
 #: components/View
+# defaultMessage: The email is incorrect
 msgid "formblock_invalidEmailMessage"
 msgstr "E-mail incorreto"
 
-# defaultMessage: Fill-in this field
 #: components/View
+# defaultMessage: Fill-in this field
 msgid "formblock_requiredFieldMessage"
 msgstr "Preencha este campo"
 
-# defaultMessage: Text at the end of the email
 #: formSchema
+# defaultMessage: Text at the end of the email
 msgid "mail_footer_label"
 msgstr "Texto ao final do e-mail."
 
-# defaultMessage: If field isn't filled in, a default text will be used
 #: formSchema
+# defaultMessage: If field isn't filled in, a default text will be used
 msgid "mail_header_description"
 msgstr "Se o campo não for preenchido, um texto padrão será usado"
 
-# defaultMessage: Text at the beginning of the email
 #: formSchema
+# defaultMessage: Text at the beginning of the email
 msgid "mail_header_label"
 msgstr "Texto no início do e-mail."
 
-# defaultMessage: remove expired data
 #: components/Sidebar
+# defaultMessage: remove expired data
 msgid "remove_data_button"
 msgstr "Remover dados antigos"
 
-# defaultMessage: To automate the removal of records that have exceeded the maximum number of days indicated in configuration, a cron must be set up on the server as indicated in the product documentation.
 #: components/Sidebar
+# defaultMessage: To automate the removal of records that have exceeded the maximum number of days indicated in configuration, a cron must be set up on the server as indicated in the product documentation.
 msgid "remove_data_cron_info"
 msgstr "Para automatizar a remoção de registros que ultrapassaram o número máximo de dias indicado na configuração, um cron deve ser configurado no servidor conforme indicado na documentação do produto."
 
-# defaultMessage: There are {record} record that have exceeded the maximum number of days.
 #: components/Sidebar
+# defaultMessage: There are {record} record that have exceeded the maximum number of days.
 msgid "remove_data_warning"
 msgstr "Há {record} respostas que ultrapassaram o número máximo de dias."
 
-# defaultMessage: Answer the question to prove that you are human
 #: components/Widget/NoRobotsCaptchaWidget
+# defaultMessage: Answer the question to prove that you are human
 msgid "resolveCaptcha"
 msgstr "Responda à pergunta para provar que você é humano."
 
-# defaultMessage: results
 #: helpers/react-select
+# defaultMessage: results
 msgid "select_risultati"
 msgstr "resultados"
 
-# defaultMessage: result
 #: helpers/react-select
+# defaultMessage: result
 msgid "select_risultato"
 msgstr "resultado"
 
-# defaultMessage: Title
 #: formSchema
+# defaultMessage: Title
 msgid "title"
 msgstr "título"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -236,6 +236,246 @@ msgstr ""
 msgid "fieldId"
 msgstr ""
 
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
+msgstr ""
+
 #: formSchema
 # defaultMessage: Form
 msgid "form"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-07-01T12:44:37.040Z\n"
+"POT-Creation-Date: 2024-09-27T10:06:31.770Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -236,6 +236,246 @@ msgstr ""
 #: components/Sidebar
 # defaultMessage: Field ID
 msgid "fieldId"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: "Autocomplete" attribute
+msgid "field_autocomplete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Additional name
+msgid "field_autocomplete_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 1
+msgid "field_autocomplete_address_line1"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 2
+msgid "field_autocomplete_address_line2"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Address line 3
+msgid "field_autocomplete_address_line3"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birthday
+msgid "field_autocomplete_bday"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth day
+msgid "field_autocomplete_bday_day"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth month
+msgid "field_autocomplete_bday_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Birth year
+msgid "field_autocomplete_bday_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder additional name
+msgid "field_autocomplete_cc_additional_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card security code
+msgid "field_autocomplete_cc_csc"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration date
+msgid "field_autocomplete_cc_exp"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration month
+msgid "field_autocomplete_cc_exp_month"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card expiration year
+msgid "field_autocomplete_cc_exp_year"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder family name
+msgid "field_autocomplete_cc_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder given name
+msgid "field_autocomplete_cc_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Cardholder name
+msgid "field_autocomplete_cc_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card number
+msgid "field_autocomplete_cc_number"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Credit card type
+msgid "field_autocomplete_cc_type"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country
+msgid "field_autocomplete_country"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Country name
+msgid "field_autocomplete_country_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Current password
+msgid "field_autocomplete_current_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>
+msgid "field_autocomplete_description"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Email
+msgid "field_autocomplete_email"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Family name
+msgid "field_autocomplete_family_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Given name
+msgid "field_autocomplete_given_name"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Prefix (ex. mr, mrs)
+msgid "field_autocomplete_honorific_prefix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Suffix (ex. jr, sr)
+msgid "field_autocomplete_honorific_suffix"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Language
+msgid "field_autocomplete_language"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Full name
+msgid "field_autocomplete_name_complete"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: New password
+msgid "field_autocomplete_new_password"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Nickname
+msgid "field_autocomplete_nickname"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization
+msgid "field_autocomplete_organization"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Organization title
+msgid "field_autocomplete_organization_title"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Photo
+msgid "field_autocomplete_photo"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Postal code
+msgid "field_autocomplete_postal_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Gender
+msgid "field_autocomplete_sex"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Street address
+msgid "field_autocomplete_street_address"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone number
+msgid "field_autocomplete_tel"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone area code
+msgid "field_autocomplete_tel_area_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone country code
+msgid "field_autocomplete_tel_country_code"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Telephone extension
+msgid "field_autocomplete_tel_extension"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Local telephone number
+msgid "field_autocomplete_tel_local"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: National telephone number
+msgid "field_autocomplete_tel_national"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction amount
+msgid "field_autocomplete_transaction_amount"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Transaction currency
+msgid "field_autocomplete_transaction_currency"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Website URL
+msgid "field_autocomplete_url"
+msgstr ""
+
+#: fieldSchema
+# defaultMessage: Username
+msgid "field_autocomplete_username"
 msgstr ""
 
 #: formSchema

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^0.3.6",
     "file-saver": "^2.0.5",
+    "react-aria-components": "1.2.0",
     "react-google-recaptcha-v3": "^1.8.0",
     "volto-subblocks": "^2.1.0"
   },

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -46,6 +46,7 @@ const Field = ({
   formHasErrors = false,
   errorMessage,
   id,
+  autocomplete,
 }) => {
   const intl = useIntl();
 
@@ -70,6 +71,7 @@ const Field = ({
           isDisabled={disabled}
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
+          autocomplete={autocomplete}
         />
       )}
       {field_type === 'textarea' && (
@@ -86,6 +88,7 @@ const Field = ({
           isDisabled={disabled}
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
+          autocomplete={autocomplete}
         />
       )}
       {field_type === 'select' && (
@@ -107,6 +110,7 @@ const Field = ({
           invalid={isInvalid().toString()}
           required={required}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
+          autocomplete={autocomplete}
         />
       )}
       {field_type === 'single_choice' && (
@@ -175,6 +179,7 @@ const Field = ({
           required={required}
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
+          autocomplete={autocomplete}
         />
       )}
       {field_type === 'attachment' && (
@@ -206,6 +211,7 @@ const Field = ({
           isDisabled={disabled}
           invalid={isInvalid().toString()}
           {...(isInvalid() ? { className: 'is-invalid' } : {})}
+          autocomplete={autocomplete}
         />
       )}
       {field_type === 'hidden' && (
@@ -247,6 +253,7 @@ const Field = ({
               formHasErrors={formHasErrors}
               invalid={isInvalid().toString()}
               {...(isInvalid() ? { className: 'is-invalid' } : {})}
+              autocomplete={autocomplete}
             />,
           ];
 
@@ -271,6 +278,7 @@ Field.propTypes = {
   value: PropTypes.any,
   formHasErrors: PropTypes.bool,
   onChange: PropTypes.func,
+  autocomplete: PropTypes.string,
 };
 
 export default Field;

--- a/src/components/Widget/DatetimeWidget.jsx
+++ b/src/components/Widget/DatetimeWidget.jsx
@@ -187,6 +187,7 @@ export class DatetimeWidgetComponent extends Component {
       widgetOptions,
       invalid,
       required,
+      autocomplete,
     } = this.props;
     const noPastDates =
       this.props.noPastDates || widgetOptions?.pattern_options?.noPastDates;
@@ -229,6 +230,7 @@ export class DatetimeWidgetComponent extends Component {
               id={`${id}-date`}
               placeholder={intl.formatMessage(messages.date)}
               {...attributes}
+              autoComplete={autocomplete}
             />
           </div>
           {!dateOnly && (
@@ -285,6 +287,7 @@ DatetimeWidgetComponent.propTypes = {
   onChange: PropTypes.func.isRequired,
   wrapped: PropTypes.bool,
   resettable: PropTypes.bool,
+  autocomplete: PropTypes.string,
 };
 
 /**
@@ -300,6 +303,7 @@ DatetimeWidgetComponent.defaultProps = {
   noPastDates: false,
   value: null,
   resettable: true,
+  autocomplete: undefined,
 };
 
 export default compose(

--- a/src/components/Widget/EmailWidget.jsx
+++ b/src/components/Widget/EmailWidget.jsx
@@ -7,7 +7,7 @@
 import { FormFieldWrapper } from '@plone/volto/components';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Input } from 'semantic-ui-react';
+import { Input } from 'react-aria-components';
 
 /** EmailWidget, a widget for email addresses
  *
@@ -33,6 +33,7 @@ const EmailWidget = (props) => {
     isDisabled,
     required,
     invalid,
+    autocomplete,
   } = props;
   const inputId = `field-${id}`;
 
@@ -64,6 +65,7 @@ const EmailWidget = (props) => {
         onClick={() => onClick()}
         minLength={minLength || null}
         maxLength={maxLength || null}
+        autoComplete={autocomplete ?? 'off'}
         {...attributes}
       />
     </FormFieldWrapper>
@@ -88,6 +90,7 @@ EmailWidget.propTypes = {
   minLength: PropTypes.number,
   maxLength: PropTypes.number,
   placeholder: PropTypes.string,
+  autocomplete: PropTypes.string,
 };
 
 /**
@@ -105,6 +108,7 @@ EmailWidget.defaultProps = {
   onClick: () => {},
   minLength: null,
   maxLength: null,
+  autocomplete: undefined,
 };
 
 export default EmailWidget;

--- a/src/components/Widget/TextWidget.jsx
+++ b/src/components/Widget/TextWidget.jsx
@@ -7,7 +7,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Input } from 'semantic-ui-react';
+import { Input } from 'react-aria-components';
 
 import { injectIntl } from 'react-intl';
 import { Icon, FormFieldWrapper } from '@plone/volto/components';
@@ -47,6 +47,7 @@ class TextWidget extends Component {
     maxLength: PropTypes.number,
     wrapped: PropTypes.bool,
     placeholder: PropTypes.string,
+    autocomplete: PropTypes.string,
   };
 
   /**
@@ -69,6 +70,7 @@ class TextWidget extends Component {
     iconAction: null,
     minLength: null,
     maxLength: null,
+    autocomplete: undefined,
   };
 
   /**
@@ -102,6 +104,7 @@ class TextWidget extends Component {
       error,
       required,
       invalid,
+      autocomplete,
     } = this.props;
 
     let attributes = {};
@@ -137,6 +140,7 @@ class TextWidget extends Component {
           onClick={() => onClick()}
           minLength={minLength || null}
           maxLength={maxLength || null}
+          autoComplete={autocomplete ?? 'off'}
         />
         {icon && iconAction && (
           <button className={`field-${id}-action-button`} onClick={iconAction}>

--- a/src/components/Widget/TextareaWidget.jsx
+++ b/src/components/Widget/TextareaWidget.jsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Label, TextArea } from 'semantic-ui-react';
+import { TextArea, Label } from 'react-aria-components';
 
 import { injectIntl } from 'react-intl';
 import { FormFieldWrapper } from '@plone/volto/components';
@@ -33,6 +33,7 @@ const TextareaWidget = (props) => {
     placeholder,
     required,
     invalid,
+    autocomplete,
   } = props;
   const [lengthError, setlengthError] = useState('');
 
@@ -70,6 +71,7 @@ const TextareaWidget = (props) => {
         onChange={({ target }) =>
           onhandleChange(id, target.value === '' ? undefined : target.value)
         }
+        autoComplete={autocomplete ?? 'off'}
         {...attributes}
       />
       {lengthError.length > 0 && (
@@ -99,6 +101,7 @@ TextareaWidget.propTypes = {
   onDelete: PropTypes.func,
   wrapped: PropTypes.bool,
   placeholder: PropTypes.string,
+  autocomplete: PropTypes.string,
 };
 
 /**
@@ -115,6 +118,7 @@ TextareaWidget.defaultProps = {
   onChange: null,
   onEdit: null,
   onDelete: null,
+  autocomplete: undefined,
 };
 
 export default injectIntl(TextareaWidget);

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -67,8 +67,202 @@ const messages = defineMessages({
     id: 'form_field_type_hidden',
     defaultMessage: 'Hidden',
   },
+  field_autocomplete: {
+    id: 'field_autocomplete',
+    defaultMessage: '"Autocomplete" attribute',
+  },
+  field_autocomplete_description: {
+    id: 'field_autocomplete_description',
+    defaultMessage:
+      'This field adds the "autocomplete" attribute to the field. This allows the browser to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>',
+  },
+  field_autocomplete_name_complete: {
+    id: 'field_autocomplete_name_complete',
+    defaultMessage: 'Full name',
+  },
+  field_autocomplete_honorific_prefix: {
+    id: 'field_autocomplete_honorific_prefix',
+    defaultMessage: 'Prefix (ex. mr, mrs)',
+  },
+  field_autocomplete_given_name: {
+    id: 'field_autocomplete_given_name',
+    defaultMessage: 'Given name',
+  },
+  field_autocomplete_additional_name: {
+    id: 'field_autocomplete_additional_name',
+    defaultMessage: 'Additional name',
+  },
+  field_autocomplete_family_name: {
+    id: 'field_autocomplete_family_name',
+    defaultMessage: 'Family name',
+  },
+  field_autocomplete_honorific_suffix: {
+    id: 'field_autocomplete_honorific_suffix',
+    defaultMessage: 'Suffix (ex. jr, sr)',
+  },
+  field_autocomplete_nickname: {
+    id: 'field_autocomplete_nickname',
+    defaultMessage: 'Nickname',
+  },
+  field_autocomplete_email: {
+    id: 'field_autocomplete_email',
+    defaultMessage: 'Email',
+  },
+  field_autocomplete_username: {
+    id: 'field_autocomplete_username',
+    defaultMessage: 'Username',
+  },
+  field_autocomplete_new_password: {
+    id: 'field_autocomplete_new_password',
+    defaultMessage: 'New password',
+  },
+  field_autocomplete_current_password: {
+    id: 'field_autocomplete_current_password',
+    defaultMessage: 'Current password',
+  },
+  field_autocomplete_organization_title: {
+    id: 'field_autocomplete_organization_title',
+    defaultMessage: 'Organization title',
+  },
+  field_autocomplete_organization: {
+    id: 'field_autocomplete_organization',
+    defaultMessage: 'Organization',
+  },
+  field_autocomplete_street_address: {
+    id: 'field_autocomplete_street_address',
+    defaultMessage: 'Street address',
+  },
+  field_autocomplete_address_line1: {
+    id: 'field_autocomplete_address_line1',
+    defaultMessage: 'Address line 1',
+  },
+  field_autocomplete_address_line2: {
+    id: 'field_autocomplete_address_line2',
+    defaultMessage: 'Address line 2',
+  },
+  field_autocomplete_address_line3: {
+    id: 'field_autocomplete_address_line3',
+    defaultMessage: 'Address line 3',
+  },
+  field_autocomplete_country: {
+    id: 'field_autocomplete_country',
+    defaultMessage: 'Country',
+  },
+  field_autocomplete_country_name: {
+    id: 'field_autocomplete_country_name',
+    defaultMessage: 'Country name',
+  },
+  field_autocomplete_postal_code: {
+    id: 'field_autocomplete_postal_code',
+    defaultMessage: 'Postal code',
+  },
+  field_autocomplete_cc_name: {
+    id: 'field_autocomplete_cc_name',
+    defaultMessage: 'Cardholder name',
+  },
+  field_autocomplete_cc_given_name: {
+    id: 'field_autocomplete_cc_given_name',
+    defaultMessage: 'Cardholder given name',
+  },
+  field_autocomplete_cc_additional_name: {
+    id: 'field_autocomplete_cc_additional_name',
+    defaultMessage: 'Cardholder additional name',
+  },
+  field_autocomplete_cc_family_name: {
+    id: 'field_autocomplete_cc_family_name',
+    defaultMessage: 'Cardholder family name',
+  },
+  field_autocomplete_cc_number: {
+    id: 'field_autocomplete_cc_number',
+    defaultMessage: 'Credit card number',
+  },
+  field_autocomplete_cc_exp: {
+    id: 'field_autocomplete_cc_exp',
+    defaultMessage: 'Credit card expiration date',
+  },
+  field_autocomplete_cc_exp_month: {
+    id: 'field_autocomplete_cc_exp_month',
+    defaultMessage: 'Credit card expiration month',
+  },
+  field_autocomplete_cc_exp_year: {
+    id: 'field_autocomplete_cc_exp_year',
+    defaultMessage: 'Credit card expiration year',
+  },
+  field_autocomplete_cc_csc: {
+    id: 'field_autocomplete_cc_csc',
+    defaultMessage: 'Credit card security code',
+  },
+  field_autocomplete_cc_type: {
+    id: 'field_autocomplete_cc_type',
+    defaultMessage: 'Credit card type',
+  },
+  field_autocomplete_transaction_currency: {
+    id: 'field_autocomplete_transaction_currency',
+    defaultMessage: 'Transaction currency',
+  },
+  field_autocomplete_transaction_amount: {
+    id: 'field_autocomplete_transaction_amount',
+    defaultMessage: 'Transaction amount',
+  },
+  field_autocomplete_language: {
+    id: 'field_autocomplete_language',
+    defaultMessage: 'Language',
+  },
+  field_autocomplete_bday: {
+    id: 'field_autocomplete_bday',
+    defaultMessage: 'Birthday',
+  },
+  field_autocomplete_bday_day: {
+    id: 'field_autocomplete_bday_day',
+    defaultMessage: 'Birth day',
+  },
+  field_autocomplete_bday_month: {
+    id: 'field_autocomplete_bday_month',
+    defaultMessage: 'Birth month',
+  },
+  field_autocomplete_bday_year: {
+    id: 'field_autocomplete_bday_year',
+    defaultMessage: 'Birth year',
+  },
+  field_autocomplete_sex: {
+    id: 'field_autocomplete_sex',
+    defaultMessage: 'Gender',
+  },
+  field_autocomplete_tel: {
+    id: 'field_autocomplete_tel',
+    defaultMessage: 'Telephone number',
+  },
+  field_autocomplete_tel_country_code: {
+    id: 'field_autocomplete_tel_country_code',
+    defaultMessage: 'Telephone country code',
+  },
+  field_autocomplete_tel_national: {
+    id: 'field_autocomplete_tel_national',
+    defaultMessage: 'National telephone number',
+  },
+  field_autocomplete_tel_area_code: {
+    id: 'field_autocomplete_tel_area_code',
+    defaultMessage: 'Telephone area code',
+  },
+  field_autocomplete_tel_local: {
+    id: 'field_autocomplete_tel_local',
+    defaultMessage: 'Local telephone number',
+  },
+  field_autocomplete_tel_extension: {
+    id: 'field_autocomplete_tel_extension',
+    defaultMessage: 'Telephone extension',
+  },
+  field_autocomplete_url: {
+    id: 'field_autocomplete_url',
+    defaultMessage: 'Website URL',
+  },
+  field_autocomplete_photo: {
+    id: 'field_autocomplete_photo',
+    defaultMessage: 'Photo',
+  },
 });
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default (props) => {
   var intl = useIntl();
   const baseFieldTypeChoices = [
@@ -96,6 +290,131 @@ export default (props) => {
         }
       : {};
 
+  const autocompleteValues = [
+    ['name', intl.formatMessage(messages.field_autocomplete_name_complete)],
+    [
+      'honorific-prefix',
+      intl.formatMessage(messages.field_autocomplete_honorific_prefix),
+    ],
+    ['given-name', intl.formatMessage(messages.field_autocomplete_given_name)],
+    [
+      'additional-name',
+      intl.formatMessage(messages.field_autocomplete_additional_name),
+    ],
+    [
+      'family-name',
+      intl.formatMessage(messages.field_autocomplete_family_name),
+    ],
+    [
+      'honorific-suffix',
+      intl.formatMessage(messages.field_autocomplete_honorific_suffix),
+    ],
+    ['nickname', intl.formatMessage(messages.field_autocomplete_nickname)],
+    ['email', intl.formatMessage(messages.field_autocomplete_email)],
+    ['username', intl.formatMessage(messages.field_autocomplete_username)],
+    [
+      'new-password',
+      intl.formatMessage(messages.field_autocomplete_new_password),
+    ],
+    [
+      'current-password',
+      intl.formatMessage(messages.field_autocomplete_current_password),
+    ],
+    [
+      'organization-title',
+      intl.formatMessage(messages.field_autocomplete_organization_title),
+    ],
+
+    [
+      'organization',
+      intl.formatMessage(messages.field_autocomplete_organization),
+    ],
+    [
+      'street-address',
+      intl.formatMessage(messages.field_autocomplete_street_address),
+    ],
+    [
+      'address-line1',
+      intl.formatMessage(messages.field_autocomplete_address_line1),
+    ],
+    [
+      'address-line2',
+      intl.formatMessage(messages.field_autocomplete_address_line2),
+    ],
+    [
+      'address-line3',
+      intl.formatMessage(messages.field_autocomplete_address_line3),
+    ],
+    ['country', intl.formatMessage(messages.field_autocomplete_country)],
+    [
+      'country-name',
+      intl.formatMessage(messages.field_autocomplete_country_name),
+    ],
+    [
+      'postal-code',
+      intl.formatMessage(messages.field_autocomplete_postal_code),
+    ],
+    ['cc-name', intl.formatMessage(messages.field_autocomplete_cc_name)],
+    [
+      'cc-given-name',
+      intl.formatMessage(messages.field_autocomplete_cc_given_name),
+    ],
+    [
+      'cc-additional-name',
+      intl.formatMessage(messages.field_autocomplete_cc_additional_name),
+    ],
+    [
+      'cc-family-name',
+      intl.formatMessage(messages.field_autocomplete_cc_family_name),
+    ],
+    ['cc-number', intl.formatMessage(messages.field_autocomplete_cc_number)],
+    ['cc-exp', intl.formatMessage(messages.field_autocomplete_cc_exp)],
+    [
+      'cc-exp-month',
+      intl.formatMessage(messages.field_autocomplete_cc_exp_month),
+    ],
+    [
+      'cc-exp-year',
+      intl.formatMessage(messages.field_autocomplete_cc_exp_year),
+    ],
+    ['cc-csc', intl.formatMessage(messages.field_autocomplete_cc_csc)],
+    ['cc-type', intl.formatMessage(messages.field_autocomplete_cc_type)],
+    [
+      'transaction-currency',
+      intl.formatMessage(messages.field_autocomplete_transaction_currency),
+    ],
+    [
+      'transaction-amount',
+      intl.formatMessage(messages.field_autocomplete_transaction_amount),
+    ],
+    ['language', intl.formatMessage(messages.field_autocomplete_language)],
+    ['bday', intl.formatMessage(messages.field_autocomplete_bday)],
+    ['bday-day', intl.formatMessage(messages.field_autocomplete_bday_day)],
+    ['bday-month', intl.formatMessage(messages.field_autocomplete_bday_month)],
+    ['bday-year', intl.formatMessage(messages.field_autocomplete_bday_year)],
+    ['sex', intl.formatMessage(messages.field_autocomplete_sex)],
+    ['tel', intl.formatMessage(messages.field_autocomplete_tel)],
+    [
+      'tel-country-code',
+      intl.formatMessage(messages.field_autocomplete_tel_country_code),
+    ],
+    [
+      'tel-national',
+      intl.formatMessage(messages.field_autocomplete_tel_national),
+    ],
+    [
+      'tel-area-code',
+      intl.formatMessage(messages.field_autocomplete_tel_area_code),
+    ],
+    ['tel-local', intl.formatMessage(messages.field_autocomplete_tel_local)],
+    [
+      'tel-extension',
+      intl.formatMessage(messages.field_autocomplete_tel_extension),
+    ],
+    ['url', intl.formatMessage(messages.field_autocomplete_url)],
+    ['photo', intl.formatMessage(messages.field_autocomplete_photo)],
+  ];
+
   var schemaExtender =
     config.blocks.blocksConfig.form.fieldTypeSchemaExtenders[props?.field_type];
   const schemaExtenderValues = schemaExtender
@@ -114,6 +433,13 @@ export default (props) => {
           'field_type',
           ...schemaExtenderValues.fields,
           ...(props?.field_type === 'static_text' ? [] : ['required']),
+          ...(props?.field_type !== 'checkbox' &&
+          props?.field_type !== 'attachment' &&
+          props?.field_type !== 'single_choice' &&
+          props?.field_type !== 'multiple_choice' &&
+          props?.field_type !== 'static_text'
+            ? ['autocomplete']
+            : []),
         ],
       },
     ],
@@ -141,6 +467,25 @@ export default (props) => {
         title: intl.formatMessage(messages.field_required),
         type: 'boolean',
         default: false,
+      },
+      autocomplete: {
+        title: intl.formatMessage(messages.field_autocomplete),
+        type: 'string',
+        description: intl.formatMessage(
+          messages.field_autocomplete_description,
+          {
+            a: (...chunks) => (
+              <a
+                href="https://www.w3.org/TR/WCAG21/#input-purposes"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {chunks}
+              </a>
+            ),
+          },
+        ),
+        choices: autocompleteValues,
       },
       ...schemaExtenderValues.properties,
     },

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -74,7 +74,7 @@ const messages = defineMessages({
   field_autocomplete_description: {
     id: 'field_autocomplete_description',
     defaultMessage:
-      'This field adds the "autocomplete" attribute to the field. This allows the browser to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>',
+      'This field adds the "autocomplete" attribute to the field. This allows to fill in the field automatically with the user info, if stored. For a complete list of these attributes and their use, visit <a>this page</a>',
   },
   field_autocomplete_name_complete: {
     id: 'field_autocomplete_name_complete',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,6 +1949,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@formatjs/ecma402-abstract@npm:2.0.0"
+  dependencies:
+    "@formatjs/intl-localematcher": 0.5.4
+    tslib: ^2.4.0
+  checksum: 0bba3b4f1a966c72d3f53173d650294fe313825b6451396c1040fb92bb86b2f771729888a1dadbc0a0074ef809229033fe8ff17c86dcb07a8ad42253b0c3a269
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@formatjs/fast-memoize@npm:2.2.0"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 8697fe72a7ece252d600a7d08105f2a2f758e2dd96f54ac0a4c508b1205a559fc08835635e1f8e5ca9dcc3ee61ce1fca4a0e7047b402f29fc96051e293a280ff
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.7.8":
+  version: 2.7.8
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.7.8"
+  dependencies:
+    "@formatjs/ecma402-abstract": 2.0.0
+    "@formatjs/icu-skeleton-parser": 1.8.2
+    tslib: ^2.4.0
+  checksum: 404d6732653632eae3b10cfa70dc57c4fb0fe500c6ef9e687e938e4cb29e18b4e5d46633c88a2c06864328eb2f4713fbb6be404c6033682370d568971e2dda0d
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.8.2":
+  version: 1.8.2
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.2"
+  dependencies:
+    "@formatjs/ecma402-abstract": 2.0.0
+    tslib: ^2.4.0
+  checksum: 8735322fa93ddd471822ba77400411660cb6221c87955cdcea159e8f9b72188106b4d4bf57d737d248810ae1974e1df4974914a6fb6045e91bf5ea22cc7fd30f
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.5.4":
+  version: 0.5.4
+  resolution: "@formatjs/intl-localematcher@npm:0.5.4"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: a0af57874fcd163add5f7a0cb1c008e9b09feb1d24cbce1263379ae0393cddd6681197a7f2f512f351a97666fc8675ed52cc17d1834266ee8fc65e9edf3435f6
+  languageName: node
+  linkType: hard
+
 "@formatjs/intl-unified-numberformat@npm:^3.2.0":
   version: 3.3.7
   resolution: "@formatjs/intl-unified-numberformat@npm:3.3.7"
@@ -2018,6 +2067,43 @@ __metadata:
   version: 2.2.5
   resolution: "@iarna/toml@npm:2.2.5"
   checksum: b63b2b2c4fd67969a6291543ada0303d45593801ee744b60f5390f183c03d9192bc67a217abb24be945158f1935f02840d9ffff40c0142aa171b5d3b6b6a3ea5
+  languageName: node
+  linkType: hard
+
+"@internationalized/date@npm:^3.5.3, @internationalized/date@npm:^3.5.5":
+  version: 3.5.5
+  resolution: "@internationalized/date@npm:3.5.5"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 610afabe7d03f55d12126798c1f853a4f244e8567c3bcc66b1da2ae1bce376aad12876dc5019a949f2a8fe3a492cd2b4d354b9350a45fec3f7c5c7ff81401fc6
+  languageName: node
+  linkType: hard
+
+"@internationalized/message@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@internationalized/message@npm:3.1.4"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+    intl-messageformat: ^10.1.0
+  checksum: 37990cf4fd666afe8d165f3c9042e88c2d95b4a03d6e67595a49d57aff938d19f91826c7c6e5cfa2863c3d8d555365e797d5979da575a835b533fd2e31876bef
+  languageName: node
+  linkType: hard
+
+"@internationalized/number@npm:^3.5.3":
+  version: 3.5.3
+  resolution: "@internationalized/number@npm:3.5.3"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: f905cb5302d5a84660fbe0264930fadf286c7a5860373c289863bc2b9d003690552743da2b3155d65e3e9fd0e49b83673caf49c306b9bab39d6e871b6777c588
+  languageName: node
+  linkType: hard
+
+"@internationalized/string@npm:^3.2.2, @internationalized/string@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "@internationalized/string@npm:3.2.3"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: aad1dd1de52fa48f17e41ad0a502bab621a08aadb8ccfc02512211d05f7111920d094b49811394a930542a98fe22522c2b5818f6d64eb38aca9638b7b4f11ccd
   languageName: node
   linkType: hard
 
@@ -2629,6 +2715,1492 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/breadcrumbs@npm:^3.5.16":
+  version: 3.5.16
+  resolution: "@react-aria/breadcrumbs@npm:3.5.16"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/link": ^3.7.4
+    "@react-aria/utils": ^3.25.2
+    "@react-types/breadcrumbs": ^3.7.7
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: f0e8aa9401930a343c8814d809fe4fa9b7395c96024f9e5312c573a65492ddeb03558133c7957d88fc1914494412f1902eb640743686bc0a4fdb3e2505adb502
+  languageName: node
+  linkType: hard
+
+"@react-aria/button@npm:^3.9.8":
+  version: 3.9.8
+  resolution: "@react-aria/button@npm:3.9.8"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/toggle": ^3.7.7
+    "@react-types/button": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 0a651b2cbf3d71e2a862ce97fcb729bb97a1f891b73546484b2cc98c3a012a2d217842032320b6ca473a4957b56063151ac4a03164aa22cb0d65883eaf84bb40
+  languageName: node
+  linkType: hard
+
+"@react-aria/calendar@npm:^3.5.11":
+  version: 3.5.11
+  resolution: "@react-aria/calendar@npm:3.5.11"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/calendar": ^3.5.4
+    "@react-types/button": ^3.9.6
+    "@react-types/calendar": ^3.4.9
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 79c4ee5bf233108c3f394f25bacf9190a452176b833a32f028acb38546be691a748248bab1bcf200b9eb7259baace0c6f0a398261f200bfa7a6df3f24cf6b3eb
+  languageName: node
+  linkType: hard
+
+"@react-aria/checkbox@npm:^3.14.6":
+  version: 3.14.6
+  resolution: "@react-aria/checkbox@npm:3.14.6"
+  dependencies:
+    "@react-aria/form": ^3.0.8
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/toggle": ^3.10.7
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/checkbox": ^3.6.8
+    "@react-stately/form": ^3.0.5
+    "@react-stately/toggle": ^3.7.7
+    "@react-types/checkbox": ^3.8.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 138979484331c5d1e6693e42e34841a30ae281166cf8ccde53cf37ec07be6326ce0ad64478b92b177d3236f86eb8348552d1584d0875261eefddbcc9e5d63366
+  languageName: node
+  linkType: hard
+
+"@react-aria/color@npm:3.0.0-beta.32":
+  version: 3.0.0-beta.32
+  resolution: "@react-aria/color@npm:3.0.0-beta.32"
+  dependencies:
+    "@react-aria/i18n": ^3.11.0
+    "@react-aria/interactions": ^3.21.2
+    "@react-aria/numberfield": ^3.11.2
+    "@react-aria/slider": ^3.7.7
+    "@react-aria/spinbutton": ^3.6.4
+    "@react-aria/textfield": ^3.14.4
+    "@react-aria/utils": ^3.24.0
+    "@react-aria/visually-hidden": ^3.8.11
+    "@react-stately/color": ^3.6.0
+    "@react-stately/form": ^3.0.2
+    "@react-types/color": 3.0.0-beta.24
+    "@react-types/shared": ^3.23.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: fcaa145f2dcf2e56c3ecac44f80bf767ea5251edcacd059889ce96e8e1e7f9d168a723864b763d66554fddc344c946d63749cdf2421317564da00c0fe199ace0
+  languageName: node
+  linkType: hard
+
+"@react-aria/combobox@npm:^3.10.3":
+  version: 3.10.3
+  resolution: "@react-aria/combobox@npm:3.10.3"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/listbox": ^3.13.3
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/menu": ^3.15.3
+    "@react-aria/overlays": ^3.23.2
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/textfield": ^3.14.8
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/combobox": ^3.9.2
+    "@react-stately/form": ^3.0.5
+    "@react-types/button": ^3.9.6
+    "@react-types/combobox": ^3.12.1
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 3ca74b7ebaf29de21402816e497b378cb0a98efa86324d324217d49ded5cb938f356f855e31e414a904fd6956482c096e75a6a4cb68ca059e7a736299aede439
+  languageName: node
+  linkType: hard
+
+"@react-aria/datepicker@npm:^3.11.2":
+  version: 3.11.2
+  resolution: "@react-aria/datepicker@npm:3.11.2"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@internationalized/number": ^3.5.3
+    "@internationalized/string": ^3.2.3
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/form": ^3.0.8
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/spinbutton": ^3.6.8
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/datepicker": ^3.10.2
+    "@react-stately/form": ^3.0.5
+    "@react-types/button": ^3.9.6
+    "@react-types/calendar": ^3.4.9
+    "@react-types/datepicker": ^3.8.2
+    "@react-types/dialog": ^3.5.12
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 28267e6c977e8d80c81b9251e0fa641539890f8dd916a11dbbceac1672c8d03ea39af713f25b080cbc17d0c504f2fa996b9f91d12c12b3d10f44aa4d89b4363e
+  languageName: node
+  linkType: hard
+
+"@react-aria/dialog@npm:^3.5.17":
+  version: 3.5.17
+  resolution: "@react-aria/dialog@npm:3.5.17"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/overlays": ^3.23.2
+    "@react-aria/utils": ^3.25.2
+    "@react-types/dialog": ^3.5.12
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 2a43a973ea3d0237cca34b03208454564be34da5b0ff5d7527d392378db6d870986f285c901378534b6e0b51bd140d492e38a6f9cd3f12a6e357ddf1ba9141b9
+  languageName: node
+  linkType: hard
+
+"@react-aria/dnd@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "@react-aria/dnd@npm:3.7.2"
+  dependencies:
+    "@internationalized/string": ^3.2.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/overlays": ^3.23.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/dnd": ^3.4.2
+    "@react-types/button": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 265a2f6b708d5bd76ad0b1e1d29a04b90c2002f93eef0a021c220678013d6144daf6471f783e0d773bf6b955247b5df9ad63163351869ce8927942cdfd7b76a5
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:^3.17.0, @react-aria/focus@npm:^3.18.2":
+  version: 3.18.2
+  resolution: "@react-aria/focus@npm:3.18.2"
+  dependencies:
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+    clsx: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1d94207f2b956fb181f1bbc8e74c244fd2398b75c38ae2c7691ab7c67b1ab831563ce2d1ec01db95b0cfeffbf080889dbea251b6a9f12d8fc3854925b874b32c
+  languageName: node
+  linkType: hard
+
+"@react-aria/form@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@react-aria/form@npm:3.0.8"
+  dependencies:
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/form": ^3.0.5
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 7e23ba71809e1acb9bc0e169bcf00583f970a88bcc84fe47e1b16c7478318d09201c2f6e2d508e6d9a1250ee41ebf812d0b2c8aa0b0960d9dcb08b8965eff770
+  languageName: node
+  linkType: hard
+
+"@react-aria/grid@npm:^3.10.3":
+  version: 3.10.3
+  resolution: "@react-aria/grid@npm:3.10.3"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/grid": ^3.9.2
+    "@react-stately/selection": ^3.16.2
+    "@react-types/checkbox": ^3.8.3
+    "@react-types/grid": ^3.2.8
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 23fdf18fc08be6846f924a812a75ba7ed41e519e285d65b6f0ad8474de1d403e09999e115d303cfbac96112e3b47ae3177c76988ed0b252cdd15af5b5dc23b42
+  languageName: node
+  linkType: hard
+
+"@react-aria/gridlist@npm:^3.8.0, @react-aria/gridlist@npm:^3.9.3":
+  version: 3.9.3
+  resolution: "@react-aria/gridlist@npm:3.9.3"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/grid": ^3.10.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/list": ^3.10.8
+    "@react-stately/tree": ^3.8.4
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 6091ac61fde8010d7e265b33c1742aee4c213bf3abc08ddbf1acba11e9f25ee94a5d3cf3810ee08f68cffbb4711fe25b8dbb4268e57bb67105058e42eb7e20a2
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.11.0, @react-aria/i18n@npm:^3.12.2":
+  version: 3.12.2
+  resolution: "@react-aria/i18n@npm:3.12.2"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@internationalized/message": ^3.1.4
+    "@internationalized/number": ^3.5.3
+    "@internationalized/string": ^3.2.3
+    "@react-aria/ssr": ^3.9.5
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 53e36b1e93c80b8a227f750d6fd46e8bdfe41added599d3fa70602707d37895ca5a2cfc8cc922cf42d8835220a1ae8ee11234b3da6b17e3c4668c21b476d31b2
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.21.2, @react-aria/interactions@npm:^3.22.2":
+  version: 3.22.2
+  resolution: "@react-aria/interactions@npm:3.22.2"
+  dependencies:
+    "@react-aria/ssr": ^3.9.5
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c856ebcec096bfeaa347def1e702a341f4bc0edbbc4bb4b8a72393bf728b02da03369afc2dd5d878a426afab84ac5b63c1dd326d59f0ce1d50d3ef94742a5966
+  languageName: node
+  linkType: hard
+
+"@react-aria/label@npm:^3.7.11":
+  version: 3.7.11
+  resolution: "@react-aria/label@npm:3.7.11"
+  dependencies:
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 6774934bd769ac27a97c987a26a4af76497fdf7d88af5a0cd77ccefb67295ca1b2a9a0d0c3af954241515ac9c197a401807b65ac2c49f833c8ae6e827d03beb8
+  languageName: node
+  linkType: hard
+
+"@react-aria/link@npm:^3.7.4":
+  version: 3.7.4
+  resolution: "@react-aria/link@npm:3.7.4"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-types/link": ^3.5.7
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: ade14a7640d7e54571244b8d6bd4f7e177d7fe647e2819436a09aeaa0428a841f75c16c09f93c25aa18d1b8c99fba9f48accecbdc94f39183cff05771c91eaad
+  languageName: node
+  linkType: hard
+
+"@react-aria/listbox@npm:^3.13.3":
+  version: 3.13.3
+  resolution: "@react-aria/listbox@npm:3.13.3"
+  dependencies:
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/list": ^3.10.8
+    "@react-types/listbox": ^3.5.1
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: ff1a386d185ddd1e4627ec9fef117d62a6e57767518e6f610ea5f5d3b250a44b370f53445bf4b173c580138258a4e42f6114b6930eac234635a6832486d24c21
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "@react-aria/live-announcer@npm:3.3.4"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: f216c6049ea77bcecec17cfbb1453e59b2b6034aa03edc6e9df74ab162a1f4197e7b07fb71b086a3b074981ef3171706f7fec4b9877901b7243c16321696a64c
+  languageName: node
+  linkType: hard
+
+"@react-aria/menu@npm:^3.14.0, @react-aria/menu@npm:^3.15.3":
+  version: 3.15.3
+  resolution: "@react-aria/menu@npm:3.15.3"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/overlays": ^3.23.2
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/menu": ^3.8.2
+    "@react-stately/tree": ^3.8.4
+    "@react-types/button": ^3.9.6
+    "@react-types/menu": ^3.9.11
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1d43336681960dc4b6c83e1a74c8704c192481df5ad0103f6992d1ebdc7b7cf56aa3d99c969bc3b9fbae571eec8b1274edfce46309d72b100fda5ca0dbc8343e
+  languageName: node
+  linkType: hard
+
+"@react-aria/meter@npm:^3.4.16":
+  version: 3.4.16
+  resolution: "@react-aria/meter@npm:3.4.16"
+  dependencies:
+    "@react-aria/progress": ^3.4.16
+    "@react-types/meter": ^3.4.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 36dcff44b9493ea93eb278f69afb1248a2352efc8cd0b7458e72924205f6c0290b5727dee587ce6675de17bb23b08baf0567043ae0629cb42ba72c197d50d5d6
+  languageName: node
+  linkType: hard
+
+"@react-aria/numberfield@npm:^3.11.2, @react-aria/numberfield@npm:^3.11.6":
+  version: 3.11.6
+  resolution: "@react-aria/numberfield@npm:3.11.6"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/spinbutton": ^3.6.8
+    "@react-aria/textfield": ^3.14.8
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/form": ^3.0.5
+    "@react-stately/numberfield": ^3.9.6
+    "@react-types/button": ^3.9.6
+    "@react-types/numberfield": ^3.8.5
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 8ca444e995842371d95c22824f8e9e1405a1602ce0d5b9379a3f31d83b6752ce2dca7d81e7aa418b1c14a0ea178b0f2dc8b4ed88e9533f4399ff29b4171ccd8a
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.23.2":
+  version: 3.23.2
+  resolution: "@react-aria/overlays@npm:3.23.2"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/ssr": ^3.9.5
+    "@react-aria/utils": ^3.25.2
+    "@react-aria/visually-hidden": ^3.8.15
+    "@react-stately/overlays": ^3.6.10
+    "@react-types/button": ^3.9.6
+    "@react-types/overlays": ^3.8.9
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: b7c82b241f4a3ce14a0602b105e0ed81e4d6bc0e6c85a151ac66ce5476e61ce1c74321739649933aa1bbebf5b537ad775ddd1cad58a41182b19a94d87e46fa66
+  languageName: node
+  linkType: hard
+
+"@react-aria/progress@npm:^3.4.16":
+  version: 3.4.16
+  resolution: "@react-aria/progress@npm:3.4.16"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/utils": ^3.25.2
+    "@react-types/progress": ^3.5.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 496d68df73dcbba35a0e144dce2bcd46622abb596ea22f686417db8a0baea51b1126189473688a5c1b3c727c21550cfc08526a4e20483c144f69e3f5fc69468b
+  languageName: node
+  linkType: hard
+
+"@react-aria/radio@npm:^3.10.7":
+  version: 3.10.7
+  resolution: "@react-aria/radio@npm:3.10.7"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/form": ^3.0.8
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/radio": ^3.10.7
+    "@react-types/radio": ^3.8.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: be98368900ffc67cc6f5d32536ad0ded2c7b07c0c58a27dd2dffd56d0c2d251bf9d52ed670edf3505a8041c44dbd644dafa6ce57cb5bbe38eb591d8daa9597d8
+  languageName: node
+  linkType: hard
+
+"@react-aria/searchfield@npm:^3.7.8":
+  version: 3.7.8
+  resolution: "@react-aria/searchfield@npm:3.7.8"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/textfield": ^3.14.8
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/searchfield": ^3.5.6
+    "@react-types/button": ^3.9.6
+    "@react-types/searchfield": ^3.5.8
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 7e96bdcb608c717d29aeb6638c3c5f0a7eb2253b2488abbb4148594ea3dcdbfd0915ce38e2f7b998ee25e305c69ebc43aba9bcdbf31046d97ae0c078b179601e
+  languageName: node
+  linkType: hard
+
+"@react-aria/select@npm:^3.14.9":
+  version: 3.14.9
+  resolution: "@react-aria/select@npm:3.14.9"
+  dependencies:
+    "@react-aria/form": ^3.0.8
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/listbox": ^3.13.3
+    "@react-aria/menu": ^3.15.3
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-aria/visually-hidden": ^3.8.15
+    "@react-stately/select": ^3.6.7
+    "@react-types/button": ^3.9.6
+    "@react-types/select": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 98f3935b56930f72838fc1e513fe0141f4ca221acd659ed9c72ed42db70b2deddef7086e96db2e61185cf68ceea5cf148141c7a7dd34656cdfa517d903032bdc
+  languageName: node
+  linkType: hard
+
+"@react-aria/selection@npm:^3.18.0, @react-aria/selection@npm:^3.19.3":
+  version: 3.19.3
+  resolution: "@react-aria/selection@npm:3.19.3"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/selection": ^3.16.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: fa37f096476907cbf0583c6d544a31afa87c23b553a82b1563d36ea6bf59b19e5917423b2678ffd8961726525329b389108aff715711692cf1827cccfaff80d2
+  languageName: node
+  linkType: hard
+
+"@react-aria/separator@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "@react-aria/separator@npm:3.4.2"
+  dependencies:
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: d6139a31dccffe2f8669c934287218bfa9127f268888d8f0d8f1482b7a58b6d034b3d5f7a92c812af28cb1d193b108b4e9e50c305647cd6278c7463e02a07a87
+  languageName: node
+  linkType: hard
+
+"@react-aria/slider@npm:^3.7.11, @react-aria/slider@npm:^3.7.7":
+  version: 3.7.11
+  resolution: "@react-aria/slider@npm:3.7.11"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/slider": ^3.5.7
+    "@react-types/shared": ^3.24.1
+    "@react-types/slider": ^3.7.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: ca0c88727d8bf1e13f11dad64ee2b1277889b50bff685a81fea233c7a60a74f82e1f56cab7337b92dad3d1c1201e4b6d01fc295f37caa0466af3b3414f84a149
+  languageName: node
+  linkType: hard
+
+"@react-aria/spinbutton@npm:^3.6.4, @react-aria/spinbutton@npm:^3.6.8":
+  version: 3.6.8
+  resolution: "@react-aria/spinbutton@npm:3.6.8"
+  dependencies:
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/utils": ^3.25.2
+    "@react-types/button": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: fe626ccd30a9d52cb57ac3b0b5dd1d3f75157e2c93b39d9e60f5e050f8f8a6857959cb51cb1710405d915e7f2bb8c45c023685b6edd943455c475c7f10cb0f24
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.9.5":
+  version: 3.9.5
+  resolution: "@react-aria/ssr@npm:3.9.5"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: cf6b256325c8a3d7983383e2b977f266c57e1f6113782a29054ce0399a227ea1613ffa4e557fec55f9d9508e69218a09d469d2843f2450769f7b3ced7eee0f31
+  languageName: node
+  linkType: hard
+
+"@react-aria/switch@npm:^3.6.7":
+  version: 3.6.7
+  resolution: "@react-aria/switch@npm:3.6.7"
+  dependencies:
+    "@react-aria/toggle": ^3.10.7
+    "@react-stately/toggle": ^3.7.7
+    "@react-types/shared": ^3.24.1
+    "@react-types/switch": ^3.5.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: d2c7ae260406d71df6edb2e7389b1af5c5ec19467894f261ced76d558467c084c1d85c22c2bccb1256faa65ce12f2286c9068d8727f749cf90ecc5701696c18d
+  languageName: node
+  linkType: hard
+
+"@react-aria/table@npm:^3.15.3":
+  version: 3.15.3
+  resolution: "@react-aria/table@npm:3.15.3"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/grid": ^3.10.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/live-announcer": ^3.3.4
+    "@react-aria/utils": ^3.25.2
+    "@react-aria/visually-hidden": ^3.8.15
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/flags": ^3.0.3
+    "@react-stately/table": ^3.12.2
+    "@react-types/checkbox": ^3.8.3
+    "@react-types/grid": ^3.2.8
+    "@react-types/shared": ^3.24.1
+    "@react-types/table": ^3.10.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 6be08ba40d2a6c7fce5fe3c11e3e9921dcbb2f1e451007f99f4f761d4562e5cbcd1de58db4cacbb31644ef6df95af00cadec782d17125bf68d80f78b06101446
+  languageName: node
+  linkType: hard
+
+"@react-aria/tabs@npm:^3.9.5":
+  version: 3.9.5
+  resolution: "@react-aria/tabs@npm:3.9.5"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/tabs": ^3.6.9
+    "@react-types/shared": ^3.24.1
+    "@react-types/tabs": ^3.3.9
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: ff3fe02826ab7808f2796301fe2766a0215c5266705f39fdd7e65b0b51cff3affcdb560cf44f1327ceadac6f4d75e9c59ac34bed721059debe196319dae92ba5
+  languageName: node
+  linkType: hard
+
+"@react-aria/tag@npm:^3.4.5":
+  version: 3.4.5
+  resolution: "@react-aria/tag@npm:3.4.5"
+  dependencies:
+    "@react-aria/gridlist": ^3.9.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/list": ^3.10.8
+    "@react-types/button": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 5a876cadc90cd5de38cc2facd786bad602439739bc939ed6622bfb7a7b732b8c98008e71e93a2cb1114edb6bc8059876573fdeaad0beeba4f27bb27df0f830a9
+  languageName: node
+  linkType: hard
+
+"@react-aria/textfield@npm:^3.14.4, @react-aria/textfield@npm:^3.14.8":
+  version: 3.14.8
+  resolution: "@react-aria/textfield@npm:3.14.8"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/form": ^3.0.8
+    "@react-aria/label": ^3.7.11
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/form": ^3.0.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@react-types/textfield": ^3.9.6
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 861e865a23aa1598058aebd86676e12ffe6b0115520998709d1c983337377d73126d4802759fc1a03da9c2f2f30b6f37caff755c1fe82c649e47afe00fe3904d
+  languageName: node
+  linkType: hard
+
+"@react-aria/toggle@npm:^3.10.7":
+  version: 3.10.7
+  resolution: "@react-aria/toggle@npm:3.10.7"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/toggle": ^3.7.7
+    "@react-types/checkbox": ^3.8.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c6ab18c046774a8865507dc85ff30a3d0931484d08bfc84ad2f024b9c78bbd0442fedfb0e5c99e74b08e62c95f66af6693c78e10f06520a0faf603b674c9fbf8
+  languageName: node
+  linkType: hard
+
+"@react-aria/toolbar@npm:3.0.0-beta.4":
+  version: 3.0.0-beta.4
+  resolution: "@react-aria/toolbar@npm:3.0.0-beta.4"
+  dependencies:
+    "@react-aria/focus": ^3.17.0
+    "@react-aria/i18n": ^3.11.0
+    "@react-aria/utils": ^3.24.0
+    "@react-types/shared": ^3.23.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: ae6fc5f49ad7f2b840cfaf91940a6225c181f551243196c407c7cdc76565d0b8e2913184cdc179101a32bb33765e624aa97416f26318b7ecb223e9bbdd0e4aa2
+  languageName: node
+  linkType: hard
+
+"@react-aria/tooltip@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@react-aria/tooltip@npm:3.7.7"
+  dependencies:
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-stately/tooltip": ^3.4.12
+    "@react-types/shared": ^3.24.1
+    "@react-types/tooltip": ^3.4.11
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: b1fba241a059100d8e9025d45611cd672b42ac7a895b5d8d6e6d7b91498d9180a314d7b5bd08d3f617cba8d10e62b1cdfc70f5470125fb9476037ce3c0eb8087
+  languageName: node
+  linkType: hard
+
+"@react-aria/tree@npm:3.0.0-alpha.0":
+  version: 3.0.0-alpha.0
+  resolution: "@react-aria/tree@npm:3.0.0-alpha.0"
+  dependencies:
+    "@react-aria/gridlist": ^3.8.0
+    "@react-aria/i18n": ^3.11.0
+    "@react-aria/selection": ^3.18.0
+    "@react-aria/utils": ^3.24.0
+    "@react-stately/tree": ^3.8.0
+    "@react-types/button": ^3.9.3
+    "@react-types/shared": ^3.23.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 2829e3a0ef448d38df6c2e599798b14cf93c2ee48134040fa82bdd85ec40a6417d45e02293e91a93b64e373f93ff7451c140afebf3f70bd8ddcf679786af74b2
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.24.0, @react-aria/utils@npm:^3.25.2":
+  version: 3.25.2
+  resolution: "@react-aria/utils@npm:3.25.2"
+  dependencies:
+    "@react-aria/ssr": ^3.9.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+    clsx: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 5866f843b852c09c0d69e082aa6120389766686607d1c67ca35c4afc4225ea4c5c426a7fb5a5ca926a0046f5c4dc2f9eebce2ffad16088730ca4b0cf49d609f7
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.11, @react-aria/visually-hidden@npm:^3.8.15":
+  version: 3.8.15
+  resolution: "@react-aria/visually-hidden@npm:3.8.15"
+  dependencies:
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/utils": ^3.25.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 4263bad7aab2d95c508c69faa420e2f0e6ee0f8a34482fe50561406c8d4bce70e1bf6b30f1d55575111466e821993a43b942fcbd78e2ba381e90ebda6ae2a285
+  languageName: node
+  linkType: hard
+
+"@react-stately/calendar@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "@react-stately/calendar@npm:3.5.4"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/calendar": ^3.4.9
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c7b61066ee0b539b0d02c49ddf5582bc30861e7fe17aa280e84844446e0b51bfc0462f8e6b8f8eb92d228b01727165deb28ed8195fee3b5303397ca322d86014
+  languageName: node
+  linkType: hard
+
+"@react-stately/checkbox@npm:^3.6.8":
+  version: 3.6.8
+  resolution: "@react-stately/checkbox@npm:3.6.8"
+  dependencies:
+    "@react-stately/form": ^3.0.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/checkbox": ^3.8.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1eae8160f8d393d8c7d4852634d87a62c4bdf3f53bb39fa9b1458d1cdb849f7d2386c8aae68a9a5d69c2916ea467e72343dfaeb839707ccbd5a45f2b8421c8b1
+  languageName: node
+  linkType: hard
+
+"@react-stately/collections@npm:^3.10.9":
+  version: 3.10.9
+  resolution: "@react-stately/collections@npm:3.10.9"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 2e3a50cc687a353476bac7b0d4e0084a18993820404c9429c88ce14bd446e809b0117ab174c4f390c2348486e87971825c9cf9001e6810fba4593ef93dc91f54
+  languageName: node
+  linkType: hard
+
+"@react-stately/color@npm:^3.6.0":
+  version: 3.7.2
+  resolution: "@react-stately/color@npm:3.7.2"
+  dependencies:
+    "@internationalized/number": ^3.5.3
+    "@internationalized/string": ^3.2.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-stately/form": ^3.0.5
+    "@react-stately/numberfield": ^3.9.6
+    "@react-stately/slider": ^3.5.7
+    "@react-stately/utils": ^3.10.3
+    "@react-types/color": 3.0.0-rc.1
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 40e31cb353c9c2d4b3da55ebf54260b861fadcceedd7742ed30232217c81bde1d5959e927e343fb54a3e2cf7c442e98a0be540abcc392c32fc81345f676f50b7
+  languageName: node
+  linkType: hard
+
+"@react-stately/combobox@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-stately/combobox@npm:3.9.2"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/form": ^3.0.5
+    "@react-stately/list": ^3.10.8
+    "@react-stately/overlays": ^3.6.10
+    "@react-stately/select": ^3.6.7
+    "@react-stately/utils": ^3.10.3
+    "@react-types/combobox": ^3.12.1
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 7850479e673f0ba243cc00a6242506473373db769ef81f9a424ffba56328b73eac8af96d5163952955dac2f4a91f13ca1c27179378775f82956d544ae0cd1c12
+  languageName: node
+  linkType: hard
+
+"@react-stately/data@npm:^3.11.6":
+  version: 3.11.6
+  resolution: "@react-stately/data@npm:3.11.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 88b2708fa5cf6fbd40c6bdb4574e2225781d4d26d4e1d08de89c2c83e1328efde5f8c69da1a7b5902d8cad9d1237e399da5c1cc081b676074d8d5e8fb2fd1fec
+  languageName: node
+  linkType: hard
+
+"@react-stately/datepicker@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@react-stately/datepicker@npm:3.10.2"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@internationalized/string": ^3.2.3
+    "@react-stately/form": ^3.0.5
+    "@react-stately/overlays": ^3.6.10
+    "@react-stately/utils": ^3.10.3
+    "@react-types/datepicker": ^3.8.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 6ca8d83bca658924963e89923c97689d1c8b9fadacb8ef5150dc5fc417437b90de3e7aba13cd5c6209472dde34b6f80f343223230587cc0e8b7ac4c1a78d3682
+  languageName: node
+  linkType: hard
+
+"@react-stately/dnd@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "@react-stately/dnd@npm:3.4.2"
+  dependencies:
+    "@react-stately/selection": ^3.16.2
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 9a6ccdc05c1cf90e21a3eeb6c5e3fb4cdfe504973843d2b5981a03c9da3aeff61a42bb18ed78c83f5d54f756c55f8fec2cce4ac324db6039ff2072571741e828
+  languageName: node
+  linkType: hard
+
+"@react-stately/flags@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@react-stately/flags@npm:3.0.3"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 8b88ccde3224efdafc947c9ee416fa45d0cf71f3d992790a6c0ba8227ca668e6d53e63fb3b2c2a3bcc80be92595c38b2473ba5b42bd81099ba24ebcf23635e8e
+  languageName: node
+  linkType: hard
+
+"@react-stately/form@npm:^3.0.2, @react-stately/form@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@react-stately/form@npm:3.0.5"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 7b78d8ec2e5f4c2957e3fb5a0b12295dd30213cfdea56783a55d01ba0a54815f54a43b98e84e9fdda1a1da10d8f28e25b823a58724846eb5b571d058fcf9d295
+  languageName: node
+  linkType: hard
+
+"@react-stately/grid@npm:^3.9.2":
+  version: 3.9.2
+  resolution: "@react-stately/grid@npm:3.9.2"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/selection": ^3.16.2
+    "@react-types/grid": ^3.2.8
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 2affc6b1afa6b480f84dc72b1dcda5e6d1eb22f44ef32b5576dc6a29e823d7317274ba7bc73bdbbc2aaf5962ea14537bb1ba987dd5a3e857d6630d4253136843
+  languageName: node
+  linkType: hard
+
+"@react-stately/list@npm:^3.10.8":
+  version: 3.10.8
+  resolution: "@react-stately/list@npm:3.10.8"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/selection": ^3.16.2
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 16e8fd6fe178dfe58e7c4b828367cf95b11a2d6300ebc72e514fa0654886d0b67c04e413ccd679ffb5769951e8ba2cb27bf677f44ce73bfbd831c5e0dcd24cae
+  languageName: node
+  linkType: hard
+
+"@react-stately/menu@npm:^3.7.0, @react-stately/menu@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "@react-stately/menu@npm:3.8.2"
+  dependencies:
+    "@react-stately/overlays": ^3.6.10
+    "@react-types/menu": ^3.9.11
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 6f7e20cc76b83df949604e605dd5841444f477c64ed51236e5b3d84ec13d209eeb99294ab21bedf7d3b274d17364b53bbd43950dc04a4c61f1b40bd1a31b3b57
+  languageName: node
+  linkType: hard
+
+"@react-stately/numberfield@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@react-stately/numberfield@npm:3.9.6"
+  dependencies:
+    "@internationalized/number": ^3.5.3
+    "@react-stately/form": ^3.0.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/numberfield": ^3.8.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 3d9cb3ac006bcc2cc7ffd4daa341caa21114aeec10bb46c9008251cc50c6f5b23f66572851492794d3b94f070d7e10872b8ef0bebc1e7e295c6f18c17340b374
+  languageName: node
+  linkType: hard
+
+"@react-stately/overlays@npm:^3.6.10":
+  version: 3.6.10
+  resolution: "@react-stately/overlays@npm:3.6.10"
+  dependencies:
+    "@react-stately/utils": ^3.10.3
+    "@react-types/overlays": ^3.8.9
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 45623d00eb6c1981b6d460255db0e4043b6d02191fb364b9c2fe83a4ec032efef04dfbd3e39636e10457674cdd709e7a59fb4a1f169e2ffdb20bfdb408ee603d
+  languageName: node
+  linkType: hard
+
+"@react-stately/radio@npm:^3.10.7":
+  version: 3.10.7
+  resolution: "@react-stately/radio@npm:3.10.7"
+  dependencies:
+    "@react-stately/form": ^3.0.5
+    "@react-stately/utils": ^3.10.3
+    "@react-types/radio": ^3.8.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1754055a38b5b240082bdc58c3e142f1ed18f549fed6f083738ca543ef2502ec4f72527ace39f0063258c9b14c3b128d480b2288b80102afbad66d7f6772cc50
+  languageName: node
+  linkType: hard
+
+"@react-stately/searchfield@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-stately/searchfield@npm:3.5.6"
+  dependencies:
+    "@react-stately/utils": ^3.10.3
+    "@react-types/searchfield": ^3.5.8
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c6804ca2108212dc61bd0daa38fe89c22071dfe611bb7eaf81a250c1e4fdff8e09f57b0d7ce5c9aebe8dc819ad389e4e112916c678b8332b9fc69012d0e6cc8e
+  languageName: node
+  linkType: hard
+
+"@react-stately/select@npm:^3.6.7":
+  version: 3.6.7
+  resolution: "@react-stately/select@npm:3.6.7"
+  dependencies:
+    "@react-stately/form": ^3.0.5
+    "@react-stately/list": ^3.10.8
+    "@react-stately/overlays": ^3.6.10
+    "@react-types/select": ^3.9.6
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: db4daef47d8f3092081d48d448de8604533a3fb68df5ed69442978fe71e6dc6a7bfa237a12ba71e1477209ffcd13335c45908a3a4ae4fe2d5c7c834f6a267583
+  languageName: node
+  linkType: hard
+
+"@react-stately/selection@npm:^3.16.2":
+  version: 3.16.2
+  resolution: "@react-stately/selection@npm:3.16.2"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: aca17fdcc22b7dbb80508ea53f231f400f0caa14bca35e9e135a87d87f70fe161177563971e1d4d9867cfc7a91f909f5e54b3f652298a5a7031f7edae0441a33
+  languageName: node
+  linkType: hard
+
+"@react-stately/slider@npm:^3.5.7":
+  version: 3.5.7
+  resolution: "@react-stately/slider@npm:3.5.7"
+  dependencies:
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@react-types/slider": ^3.7.5
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 4c1e282e45f54f7926fff25c3d955e995915fe5a8a50c45fc35517555607d8755dfd7ccad4fc6adbc7ad0b4bdd8026bac02efe9c1f9ea159b789ce6c1d1ef9c5
+  languageName: node
+  linkType: hard
+
+"@react-stately/table@npm:^3.11.7, @react-stately/table@npm:^3.12.2":
+  version: 3.12.2
+  resolution: "@react-stately/table@npm:3.12.2"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/flags": ^3.0.3
+    "@react-stately/grid": ^3.9.2
+    "@react-stately/selection": ^3.16.2
+    "@react-stately/utils": ^3.10.3
+    "@react-types/grid": ^3.2.8
+    "@react-types/shared": ^3.24.1
+    "@react-types/table": ^3.10.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1395a83634e6a948ff2260f987d4fdadaf830a6602286d6965e764c15ad82bf2060aeeb9be1f6eee37ae2b5aa783dab4d82115c04803ad053575842030f914d5
+  languageName: node
+  linkType: hard
+
+"@react-stately/tabs@npm:^3.6.9":
+  version: 3.6.9
+  resolution: "@react-stately/tabs@npm:3.6.9"
+  dependencies:
+    "@react-stately/list": ^3.10.8
+    "@react-types/shared": ^3.24.1
+    "@react-types/tabs": ^3.3.9
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: d5eed2cf80f8dbb89c1157615dfbbf31c69945a54849ee0f184bcce488b5b5da32e4df1e7be88821c1b96f2ff72097f06db9aa04de0a9ef90e8270a667393d9d
+  languageName: node
+  linkType: hard
+
+"@react-stately/toggle@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@react-stately/toggle@npm:3.7.7"
+  dependencies:
+    "@react-stately/utils": ^3.10.3
+    "@react-types/checkbox": ^3.8.3
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 1e424c4ba32a92e8d0bb2db7c03e388ab491f13d24e70c6abd4988f31d63fb86eecc5267adbfae73b30ed8912db99a24977821661cbc18b82b36152c5174e13f
+  languageName: node
+  linkType: hard
+
+"@react-stately/tooltip@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "@react-stately/tooltip@npm:3.4.12"
+  dependencies:
+    "@react-stately/overlays": ^3.6.10
+    "@react-types/tooltip": ^3.4.11
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 2a20ceec33f0c2240f906a284a51670b1c0bdd941bcf028b1a5c307f96d1818c322541dca10c17fd3c0bd334e03ff418a5a3918e714567e9e29ee76fc74be0b3
+  languageName: node
+  linkType: hard
+
+"@react-stately/tree@npm:^3.8.0, @react-stately/tree@npm:^3.8.4":
+  version: 3.8.4
+  resolution: "@react-stately/tree@npm:3.8.4"
+  dependencies:
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/selection": ^3.16.2
+    "@react-stately/utils": ^3.10.3
+    "@react-types/shared": ^3.24.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 807e58324ffe4ef02412af50c79f11ec530a95616ad6235f548ce118a879a9e674c464edfd81e035999f4cb6052d2bedaeda1d9df43c0073ad5240d11cf677d9
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.10.0, @react-stately/utils@npm:^3.10.3":
+  version: 3.10.3
+  resolution: "@react-stately/utils@npm:3.10.3"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c7f293b24674acdad49db972b7325d342cd10d9c78afede542346da7cc0055273b0c916bd11b51c8fa055f70fc8f2960aa867b847b8e7f60e9fade0f362f543b
+  languageName: node
+  linkType: hard
+
+"@react-types/breadcrumbs@npm:^3.7.7":
+  version: 3.7.7
+  resolution: "@react-types/breadcrumbs@npm:3.7.7"
+  dependencies:
+    "@react-types/link": ^3.5.7
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 56e25e5e027d794b039887e535ba74cf9f1dfc7b90f9348841fa1c0d562c26e9dfe9043dde8ae9ef664cf83ab23e4713bda800011a78602b70e8e4e2d73c005f
+  languageName: node
+  linkType: hard
+
+"@react-types/button@npm:^3.9.3, @react-types/button@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@react-types/button@npm:3.9.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: e4454a005998101a23ddf84d076646c79f679383f8a81bfd3285ff0906182f0f67f11434283d3568e846ddfb9c86972f5e79aab8f0fc9c86de243185d39b5283
+  languageName: node
+  linkType: hard
+
+"@react-types/calendar@npm:^3.4.9":
+  version: 3.4.9
+  resolution: "@react-types/calendar@npm:3.4.9"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 8b806a8d86dd321286eebd9932a2caff682c35a451438221b6325112f22668da9e551803c86c87b8ae17deba126326acb6c115b9449ebd6dbccf072ec441a6d2
+  languageName: node
+  linkType: hard
+
+"@react-types/checkbox@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-types/checkbox@npm:3.8.3"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: ac46f7fb37ea0b5942e5032c5317923fdcbe68ce853c1e2846d37a87a8b4ae4fba8934d1a3300b8f49f9c8ab470f42608e3fb9e965d9251e3b676acc01605936
+  languageName: node
+  linkType: hard
+
+"@react-types/color@npm:3.0.0-beta.24":
+  version: 3.0.0-beta.24
+  resolution: "@react-types/color@npm:3.0.0-beta.24"
+  dependencies:
+    "@react-types/shared": ^3.23.0
+    "@react-types/slider": ^3.7.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 894371276ce5c2a3623b46ea50373d44443da978bdeaa30054a5a508feb150671610d2cb591fedc8d3d70c2e6c829d9e14f604e1c75f0b850828ad09960ca616
+  languageName: node
+  linkType: hard
+
+"@react-types/color@npm:3.0.0-rc.1":
+  version: 3.0.0-rc.1
+  resolution: "@react-types/color@npm:3.0.0-rc.1"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+    "@react-types/slider": ^3.7.5
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 7671ef2db41a11da64338df6d8f7c0f81bd2e7883180689718a828e35522cfd982e0c5ad7ee3f38905cec6df0a6b59e80b232cce253c90450358def0a208f33c
+  languageName: node
+  linkType: hard
+
+"@react-types/combobox@npm:^3.12.1":
+  version: 3.12.1
+  resolution: "@react-types/combobox@npm:3.12.1"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: f214b7dd84d08355cde04f6071ec682522221ab01fee9ccda39ffcac81061b51e465508d9f85ace7e17eab14772870e1637b18b67cfd27598f8ff48481c2f86a
+  languageName: node
+  linkType: hard
+
+"@react-types/datepicker@npm:^3.8.2":
+  version: 3.8.2
+  resolution: "@react-types/datepicker@npm:3.8.2"
+  dependencies:
+    "@internationalized/date": ^3.5.5
+    "@react-types/calendar": ^3.4.9
+    "@react-types/overlays": ^3.8.9
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 18e370332e22678a1d32b670ecddf9b3dcc3bdcb32dfc9a2a6f74ed91e1930b48717a47102615b35f49c8d74a346ae5ca09291ad3238a44b0944a2408b65b444
+  languageName: node
+  linkType: hard
+
+"@react-types/dialog@npm:^3.5.12":
+  version: 3.5.12
+  resolution: "@react-types/dialog@npm:3.5.12"
+  dependencies:
+    "@react-types/overlays": ^3.8.9
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: acdcd016dd239bc72d60f75c56245158023a5eb02b1e635d97c78c65463b8aeb9a0d9aca255b62c0b9ade4086bad403cf80947bca2a6455ac401c03c7c85813e
+  languageName: node
+  linkType: hard
+
+"@react-types/form@npm:^3.7.3":
+  version: 3.7.6
+  resolution: "@react-types/form@npm:3.7.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 53360897a0cb7b26eb6c2089ea3a26702979eda6d2e002c6edb8e1ca396711eb6e5480c2946591942e0fa89ce1b004b556ef45fc5e438ce3b8e78913ba94ba50
+  languageName: node
+  linkType: hard
+
+"@react-types/grid@npm:^3.2.5, @react-types/grid@npm:^3.2.8":
+  version: 3.2.8
+  resolution: "@react-types/grid@npm:3.2.8"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 4e2da3c8e48775728f13e11ddb715ed684f8bdf6cbc06bb43c3bc6304c276326edf65b534f9383c0159db93b5680e8a5a88562cdbdf671d7c6e094669397a615
+  languageName: node
+  linkType: hard
+
+"@react-types/link@npm:^3.5.7":
+  version: 3.5.7
+  resolution: "@react-types/link@npm:3.5.7"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: c554c0c015f1d20e6a2c5cc49af65fc9daff852ce76af6f56e68199909ec9052c72cbe15c8f10d6f62485cffdfdaf7d81b0a5aeaa20828b0ab9fd0046895de65
+  languageName: node
+  linkType: hard
+
+"@react-types/listbox@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "@react-types/listbox@npm:3.5.1"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: b0732ce82be601b7f29c3c42994f9009cf23e8564e5a40439735940c549a1fa75950c38acc4434dc94cf8aed688d50dd47148d6487882095d3559f4bb5f5a1d4
+  languageName: node
+  linkType: hard
+
+"@react-types/menu@npm:^3.9.11":
+  version: 3.9.11
+  resolution: "@react-types/menu@npm:3.9.11"
+  dependencies:
+    "@react-types/overlays": ^3.8.9
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 61b27f5520183689dda94d06c9ee7cbd0e1e7b3c0c91df1f1e3cfb9f62fbd370ab2998255c19bb9cf7145a07ee1fc8324bc26e14d645214001b1bd0d8b28c780
+  languageName: node
+  linkType: hard
+
+"@react-types/meter@npm:^3.4.3":
+  version: 3.4.3
+  resolution: "@react-types/meter@npm:3.4.3"
+  dependencies:
+    "@react-types/progress": ^3.5.6
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 04787d37709dd09f3dca711def215b86d91f5e79475c08999169cf36d51d751b877939636885738414ea169ee39116fd21a84011dd7bfb4e1597d896c0aa4652
+  languageName: node
+  linkType: hard
+
+"@react-types/numberfield@npm:^3.8.5":
+  version: 3.8.5
+  resolution: "@react-types/numberfield@npm:3.8.5"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 9f67d4305b8a127ef20f7a47b90283a01eea68beec2077c0bf9f667843667372de5be751825616d7a16f4bfcc9f1ba64d47d577dd217baa4c26dfb9918fd789b
+  languageName: node
+  linkType: hard
+
+"@react-types/overlays@npm:^3.8.9":
+  version: 3.8.9
+  resolution: "@react-types/overlays@npm:3.8.9"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: e535ff53ce8835f57e2d117c0a898b1a9b876ef25abc4d3617f1a3203b102c2cc5371d73a6bcdcb65bf3a35e767e55f7930b8c9225c422686923f1e0d31bbe52
+  languageName: node
+  linkType: hard
+
+"@react-types/progress@npm:^3.5.6":
+  version: 3.5.6
+  resolution: "@react-types/progress@npm:3.5.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: cb1e1e21a1088f30d628ee2bca048905bfbd678a2007ea151ff83afb482c3d26d8f586078cbde7824005d1034331479e48919e93b029ce6101a167e830fa4701
+  languageName: node
+  linkType: hard
+
+"@react-types/radio@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-types/radio@npm:3.8.3"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 0f09a8fd5ea1875aa996842b5ec944a95407b6b023fc2d247c1db94acf2ffdf0be3895c2ad6cae216551a3623b11a66b3443abffe6861ac8d5d8dbd6075ebc14
+  languageName: node
+  linkType: hard
+
+"@react-types/searchfield@npm:^3.5.8":
+  version: 3.5.8
+  resolution: "@react-types/searchfield@npm:3.5.8"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+    "@react-types/textfield": ^3.9.6
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 946e918eb662cd9226a1f424af14240b351e327f440950316b2d27f9a7741c4466c632b2d0cc963833a5fd324cba7044e30776ef460e4cbb0b99e2f524bd262a
+  languageName: node
+  linkType: hard
+
+"@react-types/select@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@react-types/select@npm:3.9.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 491fd1d3dac9514a4f5f67e6a194ec022c64082f4293090e8323cd1c74be3d26b8e0616117ab4484ac881e8923b1445a4e3389de7da487d0f48ebc09dc49ff6b
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.23.0, @react-types/shared@npm:^3.24.1":
+  version: 3.24.1
+  resolution: "@react-types/shared@npm:3.24.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 157ed3a210bcbdcf9aae25db5df5d0650edcc8b98686654433c9526bfb4be6431838c6480fff2710cd5b68c9a521f519d6f352e919e04bf9aed52fa0d70ed887
+  languageName: node
+  linkType: hard
+
+"@react-types/slider@npm:^3.7.2, @react-types/slider@npm:^3.7.5":
+  version: 3.7.5
+  resolution: "@react-types/slider@npm:3.7.5"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 8d4f3a065f7067b386981c0a211f33a8d2ad190c8c934417fe1bd19567f5feb93087f1656827e9bf073ab260447e3725de76462e1f05a2d99ecdff4655f5bafb
+  languageName: node
+  linkType: hard
+
+"@react-types/switch@npm:^3.5.5":
+  version: 3.5.5
+  resolution: "@react-types/switch@npm:3.5.5"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 989aa9d113c5fa84a7999ca59ef56c0678197c1614a1ab9809070b4e482e06d8f42165508891876a88366f966b50b6cd9ddc66656ace26cc2c7552df517ba174
+  languageName: node
+  linkType: hard
+
+"@react-types/table@npm:^3.10.1, @react-types/table@npm:^3.9.4":
+  version: 3.10.1
+  resolution: "@react-types/table@npm:3.10.1"
+  dependencies:
+    "@react-types/grid": ^3.2.8
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: fe22e3cc6335c2a34c797eababbba9a5f43ce05bc3d92944cd78f5c5a4ef20cfb6d493c5e3e9ebd4f1b97ea405e6c33077ec76db065f0d63c4caae0ce51d99ae
+  languageName: node
+  linkType: hard
+
+"@react-types/tabs@npm:^3.3.9":
+  version: 3.3.9
+  resolution: "@react-types/tabs@npm:3.3.9"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: d55286dc003e6c150af500f9b9821c0b547f9c85ed127197789ab7e61dff720f9d2bd42bfa1fbfff7baf125662093edc366bbcd1a2a849facdf3a56fc3783a80
+  languageName: node
+  linkType: hard
+
+"@react-types/textfield@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@react-types/textfield@npm:3.9.6"
+  dependencies:
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 80625f20ed30a6d154fd54cbecf88fdb26ec835b6f84db8581053fb48a323c7c77ce20c5c2006dfee0fadc8272e5100b66f59474cff6fd949ceb8b962ec2728f
+  languageName: node
+  linkType: hard
+
+"@react-types/tooltip@npm:^3.4.11":
+  version: 3.4.11
+  resolution: "@react-types/tooltip@npm:3.4.11"
+  dependencies:
+    "@react-types/overlays": ^3.8.9
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: d6eefbd4892d09db3d92b4e81ff539c029e323fd9b082f3b29e9d1d31cfed109d9d67cb687631a2e523676901f431048d94bdf96ccc8bcf58e9385020bffdf2d
+  languageName: node
+  linkType: hard
+
 "@release-it/conventional-changelog@npm:^5.1.1":
   version: 5.1.1
   resolution: "@release-it/conventional-changelog@npm:5.1.1"
@@ -2672,6 +4244,15 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 8e331aa1412d905ecc8efd63550f58a6f77dcb510f878172004e53be63eb82650623618763001a918fc5e21257b86c45041e4e97c454ed6a2d187de084abbd11
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:^0.5.0":
+  version: 0.5.13
+  resolution: "@swc/helpers@npm:0.5.13"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: d50c2c10da6ef940af423c6b03ad9c3c94cf9de59314b1e921a7d1bcc081a6074481c9d67b655fc8fe66a73288f98b25950743792a63882bfb5793b362494fc0
   languageName: node
   linkType: hard
 
@@ -4490,6 +6071,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"client-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^6.0.0":
   version: 6.0.0
   resolution: "cliui@npm:6.0.0"
@@ -4516,6 +6104,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
   languageName: node
   linkType: hard
 
@@ -8124,6 +9719,18 @@ __metadata:
   dependencies:
     "@formatjs/intl-unified-numberformat": ^3.2.0
   checksum: 69e781b6fec47f1fe5b2dc9abba79ac74b8cb4e9b40da4acc3ef2e9c6140d3d90070fd2c055d16e48c3a8bce626bb1f547ad1e29df772aff468a377658e70e6e
+  languageName: node
+  linkType: hard
+
+"intl-messageformat@npm:^10.1.0":
+  version: 10.5.14
+  resolution: "intl-messageformat@npm:10.5.14"
+  dependencies:
+    "@formatjs/ecma402-abstract": 2.0.0
+    "@formatjs/fast-memoize": 2.2.0
+    "@formatjs/icu-messageformat-parser": 2.7.8
+    tslib: ^2.4.0
+  checksum: 7aaed153283eb83720d72df7757390515a79a1823ea9f4191c69859f1e5dd0d9a7463e5f9186fe77a31414ed98fc81619fb4c838ffdf6d481b1b370403337ca3
   languageName: node
   linkType: hard
 
@@ -12327,6 +13934,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-aria-components@npm:1.2.0":
+  version: 1.2.0
+  resolution: "react-aria-components@npm:1.2.0"
+  dependencies:
+    "@internationalized/date": ^3.5.3
+    "@internationalized/string": ^3.2.2
+    "@react-aria/color": 3.0.0-beta.32
+    "@react-aria/focus": ^3.17.0
+    "@react-aria/interactions": ^3.21.2
+    "@react-aria/menu": ^3.14.0
+    "@react-aria/toolbar": 3.0.0-beta.4
+    "@react-aria/tree": 3.0.0-alpha.0
+    "@react-aria/utils": ^3.24.0
+    "@react-stately/color": ^3.6.0
+    "@react-stately/menu": ^3.7.0
+    "@react-stately/table": ^3.11.7
+    "@react-stately/utils": ^3.10.0
+    "@react-types/color": 3.0.0-beta.24
+    "@react-types/form": ^3.7.3
+    "@react-types/grid": ^3.2.5
+    "@react-types/shared": ^3.23.0
+    "@react-types/table": ^3.9.4
+    "@swc/helpers": ^0.5.0
+    client-only: ^0.0.1
+    react-aria: ^3.33.0
+    react-stately: ^3.31.0
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 43319158c8574b2bcdaf69e0bfb6cd3599f1e5bee4f96f7c083dc061ebb3065dbde5b055614bbc0cce1760f80e619886098557356e9a7294294676e641155983
+  languageName: node
+  linkType: hard
+
+"react-aria@npm:^3.33.0":
+  version: 3.34.3
+  resolution: "react-aria@npm:3.34.3"
+  dependencies:
+    "@internationalized/string": ^3.2.3
+    "@react-aria/breadcrumbs": ^3.5.16
+    "@react-aria/button": ^3.9.8
+    "@react-aria/calendar": ^3.5.11
+    "@react-aria/checkbox": ^3.14.6
+    "@react-aria/combobox": ^3.10.3
+    "@react-aria/datepicker": ^3.11.2
+    "@react-aria/dialog": ^3.5.17
+    "@react-aria/dnd": ^3.7.2
+    "@react-aria/focus": ^3.18.2
+    "@react-aria/gridlist": ^3.9.3
+    "@react-aria/i18n": ^3.12.2
+    "@react-aria/interactions": ^3.22.2
+    "@react-aria/label": ^3.7.11
+    "@react-aria/link": ^3.7.4
+    "@react-aria/listbox": ^3.13.3
+    "@react-aria/menu": ^3.15.3
+    "@react-aria/meter": ^3.4.16
+    "@react-aria/numberfield": ^3.11.6
+    "@react-aria/overlays": ^3.23.2
+    "@react-aria/progress": ^3.4.16
+    "@react-aria/radio": ^3.10.7
+    "@react-aria/searchfield": ^3.7.8
+    "@react-aria/select": ^3.14.9
+    "@react-aria/selection": ^3.19.3
+    "@react-aria/separator": ^3.4.2
+    "@react-aria/slider": ^3.7.11
+    "@react-aria/ssr": ^3.9.5
+    "@react-aria/switch": ^3.6.7
+    "@react-aria/table": ^3.15.3
+    "@react-aria/tabs": ^3.9.5
+    "@react-aria/tag": ^3.4.5
+    "@react-aria/textfield": ^3.14.8
+    "@react-aria/tooltip": ^3.7.7
+    "@react-aria/utils": ^3.25.2
+    "@react-aria/visually-hidden": ^3.8.15
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 796769d4d5bd7070e3c603d434b3b959a5c7c7c724fff9c589cef1830521039eddb83e042eab14795be8c4a00c1ddcd2823cb8304496815d52bd3929fbb86172
+  languageName: node
+  linkType: hard
+
 "react-dev-utils@npm:^11.0.4":
   version: 11.0.4
   resolution: "react-dev-utils@npm:11.0.4"
@@ -12431,6 +14120,39 @@ __metadata:
   version: 0.9.0
   resolution: "react-refresh@npm:0.9.0"
   checksum: 6440146176f19402ffb7d66f317e40b1c42c88579b4d439b49021e38be6307c642da3e8732a72e6997b6bb1127db0da92f4aa433da4313ce8ebad0c1efa2ed4a
+  languageName: node
+  linkType: hard
+
+"react-stately@npm:^3.31.0":
+  version: 3.32.2
+  resolution: "react-stately@npm:3.32.2"
+  dependencies:
+    "@react-stately/calendar": ^3.5.4
+    "@react-stately/checkbox": ^3.6.8
+    "@react-stately/collections": ^3.10.9
+    "@react-stately/combobox": ^3.9.2
+    "@react-stately/data": ^3.11.6
+    "@react-stately/datepicker": ^3.10.2
+    "@react-stately/dnd": ^3.4.2
+    "@react-stately/form": ^3.0.5
+    "@react-stately/list": ^3.10.8
+    "@react-stately/menu": ^3.8.2
+    "@react-stately/numberfield": ^3.9.6
+    "@react-stately/overlays": ^3.6.10
+    "@react-stately/radio": ^3.10.7
+    "@react-stately/searchfield": ^3.5.6
+    "@react-stately/select": ^3.6.7
+    "@react-stately/selection": ^3.16.2
+    "@react-stately/slider": ^3.5.7
+    "@react-stately/table": ^3.12.2
+    "@react-stately/tabs": ^3.6.9
+    "@react-stately/toggle": ^3.7.7
+    "@react-stately/tooltip": ^3.4.12
+    "@react-stately/tree": ^3.8.4
+    "@react-types/shared": ^3.24.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 60678fe543baa4c74f338317183c4ef6112353ed86c2d1f8c0f62df5fd3fa624af6cd8006d7e2f7f2c2ae60dfe86c7454f2ce6f5dff58cf8281abd64cd97bcea
   languageName: node
   linkType: hard
 
@@ -14585,6 +16307,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.4.0":
+  version: 2.7.0
+  resolution: "tslib@npm:2.7.0"
+  checksum: 1606d5c89f88d466889def78653f3aab0f88692e80bb2066d090ca6112ae250ec1cfa9dbfaab0d17b60da15a4186e8ec4d893801c67896b277c17374e36e1d28
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -15004,6 +16733,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-sync-external-store@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "use-sync-external-store@npm:1.2.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: fe07c071c4da3645f112c38c0e57beb479a8838616ff4e92598256ecce527f2888c08febc7f9b2f0ce2f0e18540ba3cde41eb2035e4fafcb4f52955037098a81
+  languageName: node
+  linkType: hard
+
 "use@npm:^3.1.0":
   version: 3.1.1
   resolution: "use@npm:3.1.1"
@@ -15093,6 +16831,7 @@ __metadata:
     pofile: 1.0.10
     prettier: 3.1.0
     razzle: 4.2.17
+    react-aria-components: 1.2.0
     react-google-recaptcha-v3: ^1.8.0
     release-it: 16.1.3
     stylelint: 15.11.0


### PR DESCRIPTION
PR to fix this issue:
https://github.com/collective/volto-form-block/issues/117

Accessibility tools point out as errors the fact that form fields do not have an autocomplete attribute.
This PR aims to allow editors to set autocomplete values according to the form field role.

Since semantic-ui does not support autocomplete as a prop, I added the react-aria-components library as a dependency from this addon. However, since this library is going to be applied to volto as a whole, someday probably it won't be necessary to have it installed in this addon.
I used this library as it is the one that will be implemented, but of course I'm open to discuss and making changes in case it is not the best option.