### PR TITLE
fix: translate tab items and add missing german translations

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr "Datei auswählen"
 msgid "Close"
 msgstr "Schließen"
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr "Daten"
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr "Datei hier ablegen um die bestehende Datei zu ersetzen"
 msgid "Error"
 msgstr "Fehler"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"
@@ -229,52 +235,52 @@ msgstr "Captcha-Anbieter"
 #: helpers/conditions-list
 # defaultMessage: Contains
 msgid "condition_contains"
-msgstr ""
+msgstr "Enthält"
 
 #: helpers/conditions-list
 # defaultMessage: Greater or equal
 msgid "condition_greater_or_equal"
-msgstr ""
+msgstr "Größer oder gleich"
 
 #: helpers/conditions-list
 # defaultMessage: Greater than
 msgid "condition_greater_than"
-msgstr ""
+msgstr "Größer als"
 
 #: helpers/conditions-list
 # defaultMessage: Is empty
 msgid "condition_is_empty"
-msgstr ""
+msgstr "Ist leer"
 
 #: helpers/conditions-list
 # defaultMessage: Is equal to
 msgid "condition_is_equal_to"
-msgstr ""
+msgstr "Ist gleich"
 
 #: helpers/conditions-list
 # defaultMessage: Is not empty
 msgid "condition_is_not_empty"
-msgstr ""
+msgstr "Ist nicht leer"
 
 #: helpers/conditions-list
 # defaultMessage: Is not equal to
 msgid "condition_is_not_equal_to"
-msgstr ""
+msgstr "Ist nicht gleich"
 
 #: helpers/conditions-list
 # defaultMessage: Less or equal
 msgid "condition_less_or_equal"
-msgstr ""
+msgstr "Kleiner oder gleich"
 
 #: helpers/conditions-list
 # defaultMessage: Less than
 msgid "condition_less_than"
-msgstr ""
+msgstr "Kleiner als"
 
 #: helpers/conditions-list
 # defaultMessage: Not contains
 msgid "condition_not_contains"
-msgstr ""
+msgstr "Enthält nicht"
 
 #: formSchema
 # defaultMessage: Description
@@ -387,6 +393,7 @@ msgstr "Validierung von BCC-E-Mails mit OTP-Verifizierung"
 # defaultMessage: Prevent spam from your website. By enabling this option, you do not allow malicious users to send emails to other email addresses through your website. The OTP will be requested for all email-type fields for which the 'Send a copy of the email to this address' option is checked.
 msgid "form_email_otp_verification_description"
 msgstr "Verhindern Sie Spam von Ihrer Website. Wenn Sie diese Option aktivieren, verhindern Sie, dass böswillige Benutzer über Ihre Website E-Mails an andere E-Mail-Adressen senden. Das OTP wird für alle E-Mail-Felder angefordert, für die die Option „Eine Kopie der E-Mail an diese Adresse senden“ aktiviert ist."
+
 #: components/FormView
 # defaultMessage: There are some errors in the form.
 msgid "form_errors_validation"
@@ -421,7 +428,7 @@ msgstr "Erforderlich"
 #: fieldSchema
 # defaultMessage: If visibility conditions have been added to the field, it is advisable not to apply the requirement.
 msgid "form_field_required_info_text"
-msgstr ""
+msgstr "Nur auswählen, wenn dieses Feld immer sichtbar ist."
 
 #: fieldSchema
 # defaultMessage: Field type
@@ -491,22 +498,22 @@ msgstr "Textfeld"
 #: components/DataTable
 # defaultMessage: Items stored
 msgid "form_formDataCount"
-msgstr "{formDataCount} Element(e) gespeichert"
+msgstr "Eintrag gespeichert"
 
 #: components/DataTable
 # defaultMessage: Item stored
 msgid "form_formDataCountSingle"
-msgstr ""
+msgstr "Einträge gespeichert"
 
 #: components/DataTable
 # defaultMessage: No
 msgid "form_formValueNo"
-msgstr ""
+msgstr "Nein"
 
 #: components/DataTable
 # defaultMessage: Yes
 msgid "form_formValueYes"
-msgstr ""
+msgstr "Ja"
 
 #: components/Widget/OTPWidget
 # defaultMessage: Insert here the OTP code received at {email}
@@ -546,7 +553,7 @@ msgstr "Löschen"
 #: formSchema
 # defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
-msgstr "Kompilierte Daten speichern"
+msgstr "Daten speichern"
 
 #: components/Field
 # defaultMessage: Select a value
@@ -686,69 +693,69 @@ msgstr "Titel"
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Add condition
 msgid "visible_conditions_widget_add"
-msgstr ""
+msgstr "Bedingung hinzufügen"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: and
 msgid "visible_conditions_widget_and"
-msgstr ""
+msgstr "und"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Apply
 msgid "visible_conditions_widget_apply"
-msgstr ""
+msgstr "Anwenden"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Cancel
 msgid "visible_conditions_widget_cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Delete condition
 msgid "visible_conditions_widget_delete"
-msgstr ""
+msgstr "Bedingung entfernen"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Not checked
 msgid "visible_conditions_widget_false"
-msgstr ""
+msgstr "Nicht ausgewählt"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Select a field
 msgid "visible_conditions_widget_fields"
-msgstr ""
+msgstr "Feld auswählen"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: If
 msgid "visible_conditions_widget_if"
-msgstr ""
+msgstr "Wenn"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: For this field it is not the best solution, we recommend changing the condition.
 msgid "visible_conditions_widget_not_satisfied"
-msgstr ""
+msgstr "Diese Bedingung lässt sich bei diesem Feld-Typen nicht anwenden."
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Select a condition
 msgid "visible_conditions_widget_options"
-msgstr ""
+msgstr "Bedingung auswählen"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Write text
 msgid "visible_conditions_widget_text"
-msgstr ""
+msgstr "Text schreiben"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Visible choices if
 msgid "visible_conditions_widget_title"
-msgstr ""
+msgstr "Nur sichtbar, wenn"
 
 #: components/Widget/VisibilityConditionsWidget
 # defaultMessage: Checked
 msgid "visible_conditions_widget_true"
-msgstr ""
+msgstr "Ausgewählt"
 
 #: components/Edit
 # defaultMessage: Select the "Save Data" option in the right sidebar to enable storage and display of submitted data.
 msgid "warning_enable_save"
-msgstr ""
+msgstr "Wählen Sie die Option 'Daten speichern' in der rechten Seitenleiste, um die Speicherung und Anzeige der übermittelten Daten zu aktivieren."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr "Error"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -8,12 +8,12 @@ msgstr ""
 "POT-Creation-Date: 2022-10-18T16:54:30.102Z\n"
 "PO-Revision-Date: 2025-06-24 15:45+0200\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
-"Language-Team: ES <LL@li.org>\n"
 "Language: es\n"
-"MIME-Version: 1.0\n"
+"Language-Team: ES <LL@li.org>\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
 "Preferred-Encodings: utf-8\n"
 "Language-Code: es\n"
 "Language-Name: Español\n"
@@ -21,743 +21,751 @@ msgstr ""
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 "X-Generator: Poedit 3.6\n"
 
-# defaultMessage: Aggiungi un campo
 #: components/Edit
+# defaultMessage: Aggiungi un campo
 msgid "Add field"
 msgstr "Agregar campo"
 
-# defaultMessage: Cancel
 #: components/DataTable
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Cancelar"
 
-# defaultMessage: Choices
 #: components/Widget/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Opciones"
 
-# defaultMessage: Choose a file
 #: components/Widget/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Seleccionar Archivo"
 
-# defaultMessage: Close
 #: components/Widget/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Cerrar"
 
-# defaultMessage: Date
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Fecha"
 
-# defaultMessage: Default
 #: components/Widget/SelectWidget
+# defaultMessage: Default
 msgid "Default"
 msgstr "Por defecto"
 
-# defaultMessage: Description
 #: components/Widget/SelectWidget
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descripción"
 
-# defaultMessage: Drop file here to replace the existing file
 #: components/Widget/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Arrastre aquí el archivo para reemplazar el actual"
 
-# defaultMessage: Drop file here to upload a new file
 #: components/Widget/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Arrastre aquí el archivo para añadir un nuevo"
 
-# defaultMessage: Drop files here ...
 #: components/Widget/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Arrastrar archivos aquí..."
 
-# defaultMessage: Error
 #: components/FormView
+# defaultMessage: Error
 msgid "Error"
 msgstr "Error"
 
-# defaultMessage: Form
+#: components/Edit
 #: components/Sidebar
+# defaultMessage: Form
 msgid "Form"
 msgstr "Formulario"
 
-# defaultMessage: This site is protected by hCaptcha and its <a href="https://www.hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://www.hcaptcha.com/terms">Terms of Service</a> apply.
 #: components/Widget/HCaptchaWidget
+# defaultMessage: This site is protected by hCaptcha and its <a href="https://www.hcaptcha.com/privacy">Privacy Policy</a> and <a href="https://www.hcaptcha.com/terms">Terms of Service</a> apply.
 msgid "HCaptchaInvisibleInfo"
-msgstr "Este sitio está protegido por hCaptcha y su <a href=\"https://www.hcaptcha.com/privacy\">Política de privacidad</a> y <a href=\"https://www.hcaptcha.com/terms\">Términos de servicio</a> se aplican."
+msgstr "Este sitio está protegido por hCaptcha y su <a href="https://www.hcaptcha.com/privacy">Política de privacidad</a> y <a href="https://www.hcaptcha.com/terms">Términos de servicio</a> se aplican."
 
-# defaultMessage: No value
 #: components/Widget/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Sin valor"
 
-# defaultMessage: Replace existing file
 #: components/Widget/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Sustituir el archivo actual"
 
-# defaultMessage: Required
 #: components/Widget/SelectWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obligatorio"
 
-# defaultMessage: Select…
 #: components/Widget/SelectWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Seleccionar..."
 
-# defaultMessage: Time
 #: components/Widget/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Hora"
 
-# defaultMessage: Title
 #: components/Widget/SelectWidget
+# defaultMessage: Title
 msgid "Title"
 msgstr "Título"
 
-# defaultMessage: Used for programmatic access to the fieldset.
 #: components/Widget/SelectWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usado para acceso programático al conjunto de campos."
 
-# defaultMessage: Use Up and Down to choose options
 #: helpers/react-select
+# defaultMessage: Use Up and Down to choose options
 msgid "ay11_Use Up and Down to choose options"
 msgstr "Utilice las flechas arriba y abajo para seleccionar una opción"
 
-# defaultMessage: available
 #: helpers/react-select
+# defaultMessage: available
 msgid "ay11_select available"
 msgstr "Disponible"
 
-# defaultMessage: availables
 #: helpers/react-select
+# defaultMessage: availables
 msgid "ay11_select availables"
 msgstr "Disponibles"
 
-# defaultMessage: deselected
 #: helpers/react-select
+# defaultMessage: deselected
 msgid "ay11_select deselected"
 msgstr "No seleccionado"
 
-# defaultMessage: disabled
 #: helpers/react-select
+# defaultMessage: disabled
 msgid "ay11_select disabled"
 msgstr "Desactivado"
 
-# defaultMessage: focused
 #: helpers/react-select
+# defaultMessage: focused
 msgid "ay11_select focused"
 msgstr "Enfocado"
 
-# defaultMessage: for search term
 #: helpers/react-select
+# defaultMessage: for search term
 msgid "ay11_select for search term"
 msgstr "para la búsqueda"
 
-# defaultMessage: is disabled. Select another option.
 #: helpers/react-select
+# defaultMessage: is disabled. Select another option.
 msgid "ay11_select is disabled. Select another option."
 msgstr "está desactivado. Seleccione otra opción."
 
-# defaultMessage: option
 #: helpers/react-select
+# defaultMessage: option
 msgid "ay11_select option"
 msgstr "Opción"
 
-# defaultMessage: result
 #: helpers/react-select
+# defaultMessage: result
 msgid "ay11_select result"
 msgstr "Resultado"
 
-# defaultMessage: results
 #: helpers/react-select
+# defaultMessage: results
 msgid "ay11_select results"
 msgstr "Resultados"
 
-# defaultMessage: selected
 #: helpers/react-select
+# defaultMessage: selected
 msgid "ay11_select selected"
 msgstr "Seleccionado"
 
-# defaultMessage: value
 #: helpers/react-select
+# defaultMessage: value
 msgid "ay11_select value"
 msgstr "Valor"
 
-# defaultMessage: Use left and right to toggle between focused values, press Backspace to remove the currently focused value
 #: helpers/react-select
+# defaultMessage: Use left and right to toggle between focused values, press Backspace to remove the currently focused value
 msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
 msgstr "Utilice las flechas izquierda y derecha para pasar de un valor a otro, utiliza la tecla retroceso para eliminar el valor actual enfocado"
 
-# defaultMessage: press Tab to select the option and exit the menu
 #: helpers/react-select
+# defaultMessage: press Tab to select the option and exit the menu
 msgid "ay11_select__press Tab to select the option and exit the menu"
 msgstr "Utilice el tabulador para seleccionar la opción y salir del menú"
 
-# defaultMessage: type to refine list
 #: helpers/react-select
+# defaultMessage: type to refine list
 msgid "ay11_select__type to refine list"
 msgstr "para filtrar el listado"
 
-# defaultMessage: is_focused
 #: helpers/react-select
+# defaultMessage: is_focused
 msgid "ay11_select_is_focused"
 msgstr "está seleccionado"
 
-# defaultMessage: press Down to open the menu
 #: helpers/react-select
+# defaultMessage: press Down to open the menu
 msgid "ay11_select_press Down to open the menu"
 msgstr "Pulsa la flecha hacia abajo para abrir el menú"
 
-# defaultMessage: press Enter to select the currently focused option
 #: helpers/react-select
+# defaultMessage: press Enter to select the currently focused option
 msgid "ay11_select_press Enter to select the currently focused option"
 msgstr "Pulse Enter para seleccionar la posición seleccionada"
 
-# defaultMessage: press Escape to exit the menu
 #: helpers/react-select
+# defaultMessage: press Escape to exit the menu
 msgid "ay11_select_press Escape to exit the menu"
 msgstr "Pulse Esc para salir del menú"
 
-# defaultMessage: press left to focus selected values
 #: helpers/react-select
+# defaultMessage: press left to focus selected values
 msgid "ay11_select_press left to focus selected values"
 msgstr "Pulse la flecha hacia la izquierda para enfocar los valores seleccionados"
 
-# defaultMessage: Captcha provider
 #: formSchema
+# defaultMessage: Captcha provider
 msgid "captcha"
 msgstr "Proveedor de captchas"
 
-# defaultMessage: Contains
 #: helpers/conditions-list
+# defaultMessage: Contains
 msgid "condition_contains"
 msgstr "Contiene"
 
-# defaultMessage: Greater or equal
 #: helpers/conditions-list
+# defaultMessage: Greater or equal
 msgid "condition_greater_or_equal"
 msgstr "Mayor o igual"
 
-# defaultMessage: Greater than
 #: helpers/conditions-list
+# defaultMessage: Greater than
 msgid "condition_greater_than"
 msgstr "Mayor que"
 
-# defaultMessage: Is empty
 #: helpers/conditions-list
+# defaultMessage: Is empty
 msgid "condition_is_empty"
 msgstr "Está vacío"
 
-# defaultMessage: Is equal to
 #: helpers/conditions-list
+# defaultMessage: Is equal to
 msgid "condition_is_equal_to"
 msgstr "Es igual a"
 
-# defaultMessage: Is not empty
 #: helpers/conditions-list
+# defaultMessage: Is not empty
 msgid "condition_is_not_empty"
 msgstr "No está vacío"
 
-# defaultMessage: Is not equal to
 #: helpers/conditions-list
+# defaultMessage: Is not equal to
 msgid "condition_is_not_equal_to"
 msgstr "No es igual a"
 
-# defaultMessage: Less or equal
 #: helpers/conditions-list
+# defaultMessage: Less or equal
 msgid "condition_less_or_equal"
 msgstr "Menos o igual"
 
-# defaultMessage: Less than
 #: helpers/conditions-list
+# defaultMessage: Less than
 msgid "condition_less_than"
 msgstr "Menos que"
 
-# defaultMessage: Not contains
 #: helpers/conditions-list
+# defaultMessage: Not contains
 msgid "condition_not_contains"
 msgstr "No contiene"
 
-# defaultMessage: Description
 #: formSchema
+# defaultMessage: Description
 msgid "description"
 msgstr "Descripción"
 
-# defaultMessage: Field ID
 #: components/Sidebar
+# defaultMessage: Field ID
 msgid "fieldId"
 msgstr "ID de campo"
 
-# defaultMessage: Form
 #: formSchema
+# defaultMessage: Form
 msgid "form"
 msgstr "Formulario"
 
-# defaultMessage: Form successfully submitted
 #: components/View
+# defaultMessage: Form successfully submitted
 msgid "formSubmitted"
 msgstr "El formulario se ha enviado correctamente"
 
-# defaultMessage: Attached file will be sent via email, but not stored
 #: formSchema
+# defaultMessage: Attached file will be sent via email, but not stored
 msgid "form_attachment_send_email_info_text"
 msgstr "El archivo adjunto se enviará por correo electrónico pero no se almacenará"
 
-# defaultMessage: Cancel button label
 #: formSchema
+# defaultMessage: Cancel button label
 msgid "form_cancel_label"
 msgstr "Etiqueta del botón cancelar"
 
-# defaultMessage: Clear data
 #: components/DataTable
+# defaultMessage: Clear data
 msgid "form_clear_data"
 msgstr "Borrar datos"
 
-# defaultMessage: Are you sure you want to delete all saved items?
 #: components/DataTable
+# defaultMessage: Are you sure you want to delete all saved items?
 msgid "form_confirmClearData"
 msgstr "¿Está seguro de que quiere borrar todos los datos guardados?"
 
+#: components/Edit
+#: components/FormView
 # defaultMessage: Annulla
-#: components/Edit components/FormView
 msgid "form_default_cancel_label"
 msgstr "Cancelar"
 
-# defaultMessage: Default sender
 #: formSchema
+# defaultMessage: Default sender
 msgid "form_default_from"
 msgstr "Remitente por defecto"
 
-# defaultMessage: Mail subject
 #: formSchema
+# defaultMessage: Mail subject
 msgid "form_default_subject"
 msgstr "Asunto"
 
-# defaultMessage: Use the ${field_id} syntax to add a form value to the email subject
 #: formSchema
+# defaultMessage: Use the ${field_id} syntax to add a form value to the email subject
 msgid "form_default_subject_description"
 msgstr "Utilice la sintaxis ${field_id} para añadir un valor de formulario al asunto del correo electrónico"
 
+#: components/Edit
+#: components/FormView
 # defaultMessage: Invia
-#: components/Edit components/FormView
 msgid "form_default_submit_label"
 msgstr "Enviar"
 
-# defaultMessage: Export data
 #: components/DataTable
+# defaultMessage: Export data
 msgid "form_edit_exportCsv"
 msgstr "Exportar datos"
 
-# defaultMessage: Please, fill-in required configuration fields in sidebar. The form will be not displayed in view mode until required fields are filled-in.
 #: components/ValidateConfigForm
+# defaultMessage: Please, fill-in required configuration fields in sidebar. The form will be not displayed in view mode until required fields are filled-in.
 msgid "form_edit_fill_required_configuration_fields"
 msgstr "Por favor, complete los campos de configuración obligatorios en la barra lateral. El formulario no se mostrará en modo de visualización hasta que se completen los campos obligatorios."
 
-# defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 #: helpers/validators
+# defaultMessage: The e-mail entered in the 'From' field must be a valid e-mail address.
 msgid "form_edit_invalid_from_email"
 msgstr "El correo electrónico introducido en el campo 'Remitente por defecto' debe ser una dirección de correo electrónico válida."
 
-# defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 #: helpers/validators
+# defaultMessage: The e-mail entered in the 'Receipients' field must be a valid e-mail address.
 msgid "form_edit_invalid_to_email"
 msgstr "El correo electrónico introducido en el campo 'Destinatarios' debe ser una dirección de correo electrónico válida."
 
-# defaultMessage: Please, verify this configuration errors in sidebar. The form will be not displayed in view mode until this errors fields are not fixed.
 #: components/ValidateConfigForm
+# defaultMessage: Please, verify this configuration errors in sidebar. The form will be not displayed in view mode until this errors fields are not fixed.
 msgid "form_edit_other_errors"
 msgstr "Por favor, verifique los errores de configuración en la barra lateral. El formulario no se mostrará en modo de visualización hasta que estos campos no se corrijan."
 
-# defaultMessage: Attenzione!
 #: components/Edit
+# defaultMessage: Attenzione!
 msgid "form_edit_warning"
 msgstr "¡Atención!"
 
-# defaultMessage: Enter a field of type 'Sender E-mail'. If it is not present, or it is present but not filled in by the user, the sender address of the e-mail will be the one configured in the right sidebar.
 #: components/Edit
+# defaultMessage: Enter a field of type 'Sender E-mail'. If it is not present, or it is present but not filled in by the user, the sender address of the e-mail will be the one configured in the right sidebar.
 msgid "form_edit_warning_from"
 msgstr "Introduzca un campo de tipo 'Correo electrónico del remitente'. Si no está presente o si está presente pero el usuario no lo rellena, el remitente del mensaje será el configurado por defecto en el formulario."
 
-# defaultMessage: Validate BCC emails with OTP verification
 #: formSchema
+# defaultMessage: Validate BCC emails with OTP verification
 msgid "form_email_otp_verification"
 msgstr "Validar correos electrónicos CCO con verificación OTP"
 
-# defaultMessage: Prevent spam from your website. By enabling this option, you do not allow malicious users to send emails to other email addresses through your website. The OTP will be requested for all email-type fields for which the 'Send a copy of the email to this address' option is checked.
 #: formSchema
+# defaultMessage: Prevent spam from your website. By enabling this option, you do not allow malicious users to send emails to other email addresses through your website. The OTP will be requested for all email-type fields for which the 'Send a copy of the email to this address' option is checked.
 msgid "form_email_otp_verification_description"
 msgstr "Evite el spam desde su sitio web. Al activar esta opción, no permite que usuarios malintencionados envíen correos electrónicos a otras direcciones de correo electrónico a través de su sitio web. Se solicitará la OTP para todos los campos de tipo correo electrónico para los que esté marcada la opción 'Enviar una copia del correo electrónico a esta dirección'."
 
-# defaultMessage: There are some errors in the form.
 #: components/FormView
+# defaultMessage: There are some errors in the form.
 msgid "form_errors_validation"
 msgstr "Hay algunos errores en el formulario."
 
-# defaultMessage: Description
 #: fieldSchema
+# defaultMessage: Description
 msgid "form_field_description"
 msgstr "Descripción"
 
-# defaultMessage: Value for field
 #: components/FieldTypeSchemaExtenders/HiddenSchemaExtender
+# defaultMessage: Value for field
 msgid "form_field_input_value"
 msgstr "Valor del campo"
 
-# defaultMessage: Possible values
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
 #: components/FieldTypeSchemaExtenders/SelectionSchemaExtender
+# defaultMessage: Possible values
 msgid "form_field_input_values"
 msgstr "Valores posibles"
 
-# defaultMessage: Label
 #: fieldSchema
+# defaultMessage: Label
 msgid "form_field_label"
 msgstr "Etiqueta"
 
-# defaultMessage: Required
 #: fieldSchema
+# defaultMessage: Required
 msgid "form_field_required"
 msgstr "Obligatorio"
 
-# defaultMessage: If visibility conditions have been added to the field, it is advisable not to apply the requirement.
 #: fieldSchema
+# defaultMessage: If visibility conditions have been added to the field, it is advisable not to apply the requirement.
 msgid "form_field_required_info_text"
 msgstr "Si se han añadido condiciones de visibilidad al campo, es aconsejable no aplicar el requisito."
 
-# defaultMessage: Field type
 #: fieldSchema
+# defaultMessage: Field type
 msgid "form_field_type"
 msgstr "Tipo de campo"
 
-# defaultMessage: Attachment
 #: fieldSchema
+# defaultMessage: Attachment
 msgid "form_field_type_attachment"
 msgstr "Adjunto"
 
-# defaultMessage: Any attachments can be emailed, but will not be saved.
 #: fieldSchema
+# defaultMessage: Any attachments can be emailed, but will not be saved.
 msgid "form_field_type_attachment_info_text"
 msgstr "Los adjuntos se pueden enviar por correo electrónico pero no se guardarán."
 
-# defaultMessage: Checkbox
 #: fieldSchema
+# defaultMessage: Checkbox
 msgid "form_field_type_checkbox"
 msgstr "Cuadro de selección"
 
-# defaultMessage: Date
 #: fieldSchema
+# defaultMessage: Date
 msgid "form_field_type_date"
 msgstr "Fecha"
 
-# defaultMessage: E-mail
 #: fieldSchema
+# defaultMessage: E-mail
 msgid "form_field_type_from"
 msgstr "Correo electrónico"
 
-# defaultMessage: Hidden
 #: fieldSchema
+# defaultMessage: Hidden
 msgid "form_field_type_hidden"
 msgstr "Oculto"
 
-# defaultMessage: Multiple choice
 #: fieldSchema
+# defaultMessage: Multiple choice
 msgid "form_field_type_multiple_choice"
 msgstr "Selección múltiple"
 
-# defaultMessage: List
 #: fieldSchema
+# defaultMessage: List
 msgid "form_field_type_select"
 msgstr "Lista"
 
-# defaultMessage: Single choice
 #: fieldSchema
+# defaultMessage: Single choice
 msgid "form_field_type_single_choice"
 msgstr "Selección única"
 
-# defaultMessage: Static text
 #: fieldSchema
+# defaultMessage: Static text
 msgid "form_field_type_static_text"
 msgstr "Texto estático"
 
-# defaultMessage: Text
 #: fieldSchema
+# defaultMessage: Text
 msgid "form_field_type_text"
 msgstr "Texto"
 
-# defaultMessage: Textarea
 #: fieldSchema
+# defaultMessage: Textarea
 msgid "form_field_type_textarea"
 msgstr "Campo de texto"
 
-# defaultMessage: Items stored
 #: components/DataTable
+# defaultMessage: Items stored
 msgid "form_formDataCount"
 msgstr "{formDataCount} elemento(s) guardados"
 
-# defaultMessage: Item stored
 #: components/DataTable
+# defaultMessage: Item stored
 msgid "form_formDataCountSingle"
 msgstr "Elemento guardado"
 
-# defaultMessage: No
 #: components/DataTable
+# defaultMessage: No
 msgid "form_formValueNo"
 msgstr "No"
 
-# defaultMessage: Yes
 #: components/DataTable
+# defaultMessage: Yes
 msgid "form_formValueYes"
 msgstr "Sí"
 
-# defaultMessage: Insert here the OTP code received at {email}
 #: components/Widget/OTPWidget
+# defaultMessage: Insert here the OTP code received at {email}
 msgid "form_insert_otp"
 msgstr "Inserte el código OTP recibido en {email}"
 
-# defaultMessage: Manage data
 #: formSchema
+# defaultMessage: Manage data
 msgid "form_manage_data"
 msgstr "Administrar datos"
 
-# defaultMessage: You can send a new OTP code in
 #: components/Widget/OTPWidget
+# defaultMessage: You can send a new OTP code in
 msgid "form_otp_countdown"
 msgstr "Puedes enviar un nuevo código OTP en"
 
-# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 #: components/Widget/OTPWidget
+# defaultMessage: OTP code was sent to {email}. Check your email and insert the received OTP code into the field above.
 msgid "form_otp_send"
 msgstr "El código OTP se ha enviado a {email}. Revise su correo electrónico e introduzca el código recibido."
 
-# defaultMessage: Data wipe
 #: formSchema
+# defaultMessage: Data wipe
 msgid "form_remove_data_after_days"
 msgstr "Borrado de datos"
 
-# defaultMessage: Number of days after which, the data should be deleted
 #: formSchema
+# defaultMessage: Number of days after which, the data should be deleted
 msgid "form_remove_data_after_days_helptext"
 msgstr "Número de días después de los cuales se deben eliminar los datos"
 
-# defaultMessage: Clear
 #: components/FormResult
+# defaultMessage: Clear
 msgid "form_reset"
 msgstr "Borrar"
 
-# defaultMessage: Store compiled data
 #: formSchema
+# defaultMessage: Store compiled data
 msgid "form_save_persistent_data"
 msgstr "Guardar datos recopilados"
 
-# defaultMessage: Select a value
 #: components/Field
+# defaultMessage: Select a value
 msgid "form_select_a_value"
 msgstr "Seleccione un valor"
 
-# defaultMessage: Send email to recipient
 #: formSchema
+# defaultMessage: Send email to recipient
 msgid "form_send_email"
 msgstr "Enviar correo electrónico al receptor"
 
-# defaultMessage: Message of sending confirmed
 #: formSchema
+# defaultMessage: Message of sending confirmed
 msgid "form_send_message"
 msgstr "Mensaje de envío confirmado"
 
-# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 #: formSchema
+# defaultMessage: You can add the value of a filled field in the form by inserting its ID between curly brackets preceded by $, example: ${field_id}; you can add also html elements such as links <a>, new line <br />, bold <b> and italic <i> formatting.
 msgid "form_send_message_helptext"
 msgstr "Puede agregar el valor de un campo lleno en el formulario insertando su ID entre llaves precedidas de $, ejemplo: ${field_id}; también puede agregar elementos html como enlaces <a>, nueva línea <br />, negrita <b> y cursiva <i>."
 
-# defaultMessage: Send OTP code to {email}
 #: components/Widget/OTPWidget
+# defaultMessage: Send OTP code to {email}
 msgid "form_send_otp_to"
 msgstr "Envíe el código OTP a {email}"
 
-# defaultMessage: Show cancel button
 #: formSchema
+# defaultMessage: Show cancel button
 msgid "form_show_cancel"
 msgstr "Mostrar botón cancelar"
 
-# defaultMessage: Submit button label
 #: formSchema
+# defaultMessage: Submit button label
 msgid "form_submit_label"
 msgstr "Etiqueta del botón de envío"
 
-# defaultMessage: Sent!
 #: components/FormResult
+# defaultMessage: Sent!
 msgid "form_submit_success"
 msgstr "Enviado"
 
-# defaultMessage: Recipients
 #: formSchema
+# defaultMessage: Recipients
 msgid "form_to"
 msgstr "Destinatarios"
 
-# defaultMessage: Send an email copy to this address
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Send an email copy to this address
 msgid "form_useAsBCC"
 msgstr "Enviar una copia del e-mail a esta dirección"
 
-# defaultMessage: If selected, a copy of email will alse be sent to this address.
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, a copy of email will alse be sent to this address.
 msgid "form_useAsBCC_description"
 msgstr "Si está seleccionado, una copia del mensaje se enviará a esta dirección"
 
-# defaultMessage: Use as 'reply to'
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: Use as 'reply to'
 msgid "form_useAsReplyTo"
 msgstr "Utilizar como 'Responder a'"
 
-# defaultMessage: If selected, this will be the address the receiver can use to reply.
 #: components/FieldTypeSchemaExtenders/FromSchemaExtender
+# defaultMessage: If selected, this will be the address the receiver can use to reply.
 msgid "form_useAsReplyTo_description"
 msgstr "Si está seleccionado el valor de este campo se utilizará como cabecera 'Responder A' en el correo electrónico enviado al receptor"
 
-# defaultMessage: Invalid field value
 #: components/View
+# defaultMessage: Invalid field value
 msgid "formblock_defaultInvalidFieldMessage"
 msgstr "Valor de campo no válido"
 
-# defaultMessage: Please, insert the OTP code recived via email.
 #: components/View
+# defaultMessage: Please, insert the OTP code recived via email.
 msgid "formblock_insertOtp_error"
 msgstr "Por favor, introduzca el código OTP recibido por correo electrónico."
 
-# defaultMessage: The email is incorrect
 #: components/View
+# defaultMessage: The email is incorrect
 msgid "formblock_invalidEmailMessage"
 msgstr "El correo electrónico es incorrecto."
 
-# defaultMessage: Fill-in this field
 #: components/View
+# defaultMessage: Fill-in this field
 msgid "formblock_requiredFieldMessage"
 msgstr "Rellena este campo"
 
-# defaultMessage: Text at the end of the email
 #: formSchema
+# defaultMessage: Text at the end of the email
 msgid "mail_footer_label"
 msgstr "Texto al final del correo electrónico"
 
-# defaultMessage: If field isn't filled in, a default text will be used
 #: formSchema
+# defaultMessage: If field isn't filled in, a default text will be used
 msgid "mail_header_description"
 msgstr "Si el campo no se rellena, se utilizará un texto por defecto"
 
-# defaultMessage: Text at the beginning of the email
 #: formSchema
+# defaultMessage: Text at the beginning of the email
 msgid "mail_header_label"
 msgstr "Texto al principio del correo electrónico"
 
-# defaultMessage: remove expired data
 #: components/Sidebar
+# defaultMessage: remove expired data
 msgid "remove_data_button"
 msgstr "eliminar datos caducados"
 
-# defaultMessage: To automate the removal of records that have exceeded the maximum number of days indicated in configuration, a cron must be set up on the server as indicated in the product documentation.
 #: components/Sidebar
+# defaultMessage: To automate the removal of records that have exceeded the maximum number of days indicated in configuration, a cron must be set up on the server as indicated in the product documentation.
 msgid "remove_data_cron_info"
 msgstr "Para automatizar la eliminación de registros que hayan superado el número máximo de días indicado en configuración, se debe configurar un cron en el servidor tal y como se indica en la documentación del producto."
 
-# defaultMessage: There are {record} record that have exceeded the maximum number of days.
 #: components/Sidebar
+# defaultMessage: There are {record} record that have exceeded the maximum number of days.
 msgid "remove_data_warning"
 msgstr "Hay {record} registros que han superado el número máximo de días."
 
-# defaultMessage: Answer the question to prove that you are human
 #: components/Widget/NoRobotsCaptchaWidget
+# defaultMessage: Answer the question to prove that you are human
 msgid "resolveCaptcha"
 msgstr "Responde la pregunta para demostrar que eres humano"
 
-# defaultMessage: results
 #: helpers/react-select
+# defaultMessage: results
 msgid "select_risultati"
 msgstr "Resultados"
 
-# defaultMessage: result
 #: helpers/react-select
+# defaultMessage: result
 msgid "select_risultato"
 msgstr "Resultado"
 
-# defaultMessage: Title
 #: formSchema
+# defaultMessage: Title
 msgid "title"
 msgstr "Título"
 
-# defaultMessage: Add condition
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Add condition
 msgid "visible_conditions_widget_add"
 msgstr "Añadir condición"
 
-# defaultMessage: and
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: and
 msgid "visible_conditions_widget_and"
 msgstr "y"
 
-# defaultMessage: Apply
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Apply
 msgid "visible_conditions_widget_apply"
 msgstr "Aplicar"
 
-# defaultMessage: Cancel
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Cancel
 msgid "visible_conditions_widget_cancel"
 msgstr "Cancelar"
 
-# defaultMessage: Delete condition
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Delete condition
 msgid "visible_conditions_widget_delete"
 msgstr "Eliminar condición"
 
-# defaultMessage: Not checked
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Not checked
 msgid "visible_conditions_widget_false"
 msgstr "No marcado"
 
-# defaultMessage: Select a field
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Select a field
 msgid "visible_conditions_widget_fields"
 msgstr "Seleccione un campo"
 
-# defaultMessage: If
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: If
 msgid "visible_conditions_widget_if"
 msgstr "Si"
 
-# defaultMessage: For this field it is not the best solution, we recommend changing the condition.
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: For this field it is not the best solution, we recommend changing the condition.
 msgid "visible_conditions_widget_not_satisfied"
 msgstr "Para este campo no es la mejor solución, recomendamos cambiar la condición."
 
-# defaultMessage: Select a condition
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Select a condition
 msgid "visible_conditions_widget_options"
 msgstr "Seleccione una condición"
 
-# defaultMessage: Write text
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Write text
 msgid "visible_conditions_widget_text"
 msgstr "Escribir texto"
 
-# defaultMessage: Visible choices if
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Visible choices if
 msgid "visible_conditions_widget_title"
 msgstr "Opciones visibles si"
 
-# defaultMessage: Checked
 #: components/Widget/VisibilityConditionsWidget
+# defaultMessage: Checked
 msgid "visible_conditions_widget_true"
 msgstr "Marcado"
 
-# defaultMessage: Select the "Save Data" option in the right sidebar to enable storage and display of submitted data.
 #: components/Edit
+# defaultMessage: Select the "Save Data" option in the right sidebar to enable storage and display of submitted data.
 msgid "warning_enable_save"
-msgstr "Seleccione la opción \"Guardar datos\" en la barra lateral derecha para permitir el almacenamiento y la visualización de los datos enviados."
+msgstr "Seleccione la opción "Guardar datos" en la barra lateral derecha para permitir el almacenamiento y la visualización de los datos enviados."

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -38,6 +38,11 @@ msgstr "Aukeratu fitxategia"
 msgid "Close"
 msgstr "Itxi"
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -73,6 +78,7 @@ msgstr "Arrastatu fitxategiak hona..."
 msgid "Error"
 msgstr "Errorea"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr "Erreur"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr "Scegli un file"
 msgid "Close"
 msgstr "Chiudi"
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr "Trascina i file qui"
 msgid "Error"
 msgstr "Errore"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr "Kies een bestand"
 msgid "Close"
 msgstr "Sluiten"
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -42,6 +42,11 @@ msgstr "Escolha um arquivo"
 msgid "Close"
 msgstr "Fechar"
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -77,6 +82,7 @@ msgstr "Soltar aquivos aqui…"
 msgid "Error"
 msgstr "Erro"
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -36,6 +36,11 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
+msgstr ""
+
 #: components/Widget/DatetimeWidget
 # defaultMessage: Date
 msgid "Date"
@@ -71,6 +76,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-04-30T13:10:48.470Z\n"
+"POT-Creation-Date: 2025-10-16T12:13:06.370Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -36,6 +36,11 @@ msgstr ""
 #: components/Widget/SelectWidget
 # defaultMessage: Close
 msgid "Close"
+msgstr ""
+
+#: components/Edit
+# defaultMessage: data
+msgid "Data"
 msgstr ""
 
 #: components/Widget/DatetimeWidget
@@ -73,6 +78,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#: components/Edit
 #: components/Sidebar
 # defaultMessage: Form
 msgid "Form"

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -41,6 +41,14 @@ const messages = defineMessages({
     defaultMessage:
       'Select the "Save Data" option in the right sidebar to enable storage and display of submitted data.',
   },
+  form: {
+    id: 'Form',
+    defaultMessage: 'Form',
+  },
+  data: {
+    id: 'Data',
+    defaultMessage: 'data',
+  },
 });
 
 /**
@@ -91,7 +99,7 @@ class Edit extends SubblocksEdit {
               <Tab
                 panes={[
                   {
-                    menuItem: 'Form',
+                    menuItem: this.props.intl.formatMessage(messages.form),
                     render: () => (
                       <TabPane>
                         {this.state.subblocks.map((subblock, subindex) => (
@@ -136,7 +144,7 @@ class Edit extends SubblocksEdit {
                     ),
                   },
                   {
-                    menuItem: 'Data',
+                    menuItem: this.props.intl.formatMessage(messages.data),
                     render: () => (
                       <TabPane className="container">
                         {this.props.data.store ? (


### PR DESCRIPTION
allow translation of the tab titles "form" and "data" 

also add missing german translations