### PR TITLE
fix: german translation for items stored

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -498,12 +498,12 @@ msgstr "Textfeld"
 #: components/DataTable
 # defaultMessage: Items stored
 msgid "form_formDataCount"
-msgstr "Eintrag gespeichert"
+msgstr "Einträge gespeichert"
 
 #: components/DataTable
 # defaultMessage: Item stored
 msgid "form_formDataCountSingle"
-msgstr "Einträge gespeichert"
+msgstr "Eintrag gespeichert"
 
 #: components/DataTable
 # defaultMessage: No


### PR DESCRIPTION
terms for plural and singular were mixed up