### PR TITLE
fix: added unique field name to form block subfields

### DIFF
--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -36,7 +36,7 @@ const Field = ({
   description,
   name,
   field_type,
-  required,
+  field_id,
   input_values,
   value,
   onChange,
@@ -46,7 +46,9 @@ const Field = ({
   formHasErrors = false,
   errorMessage,
   id,
+  ...props
 }) => {
+  const required = props[`required-${field_id}`];
   const intl = useIntl();
 
   const isInvalid = () => {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -103,7 +103,7 @@ const Sidebar = ({
           {data.subblocks &&
             data.subblocks.map((subblock, index) => {
               return (
-                <div key={'subblock' + index}>
+                <div key={'subblock' + subblock.id}>
                   <Accordion.Title
                     active={selected === index}
                     index={index}

--- a/src/fieldSchema.js
+++ b/src/fieldSchema.js
@@ -119,7 +119,9 @@ export default (props) => {
           'description',
           'field_type',
           ...schemaExtenderValues.fields,
-          ...(props?.field_type === 'static_text' ? [] : ['required']),
+          ...(props?.field_type === 'static_text'
+            ? []
+            : [`required-${props?.field_id}`]),
           'visibility_conditions',
         ],
       },
@@ -144,7 +146,7 @@ export default (props) => {
         ],
         ...attachmentDescription,
       },
-      required: {
+      [`required-${props?.field_id}`]: {
         title: intl.formatMessage(messages.field_required),
         type: 'boolean',
         default: false,


### PR DESCRIPTION
Starting from Volto version 17.22.3, the CheckboxWidget now includes an id field.
However, this id is set using the fieldset name rather than the field’s own id.

In the form sidebar, we have subblocks containing several fields that define the properties for each configurable field within the block.
Since all of these fields include the "required" and "unique" options as checkboxes, the same id (i.e. the field name) was being assigned to all of them.
As a result, the closure was incorrect, because the form always referenced the first field with that id.