### PR TITLE
feat: display all required field errors after first submit

### DIFF
--- a/src/components/FormView.jsx
+++ b/src/components/FormView.jsx
@@ -102,6 +102,7 @@ const FormView = ({
               onSubmit={submit}
               autoComplete="off"
               method="post"
+              noValidate
             >
               <Grid columns={1} padded="vertically">
                 {data.static_fields?.map((field) => (


### PR DESCRIPTION
Remove browser validation so that all required field errors are displayed on the first submission. Browser validation is done field by field.